### PR TITLE
Guard against None or empty string data folders.

### DIFF
--- a/sentinelhub/aws.py
+++ b/sentinelhub/aws.py
@@ -28,8 +28,8 @@ class AwsService(ABC):
                       If parameter is set to ``None`` the list will be set automatically.
     :type metafiles: list(str) or None
     """
-    def __init__(self, parent_folder='', bands=None, metafiles=None):
-        self.parent_folder = parent_folder
+    def __init__(self, parent_folder=None, bands=None, metafiles=None):
+        self.parent_folder = parent_folder or '.'
         self.bands = self.parse_bands(bands)
         self.metafiles = self.parse_metafiles(metafiles)
 

--- a/sentinelhub/data_request.py
+++ b/sentinelhub/data_request.py
@@ -32,7 +32,7 @@ class DataRequest(ABC):
     :type data_folder: str
     """
     def __init__(self, *, data_folder=None):
-        self.data_folder = data_folder.rstrip('/') if data_folder else None
+        self.data_folder = data_folder.rstrip('/') if data_folder else '.'
 
         self.download_list = []
         self.folder_list = []

--- a/sentinelhub/download.py
+++ b/sentinelhub/download.py
@@ -41,7 +41,7 @@ class DownloadRequest:
 
     :param url: url to Sentinel Hub's services or other sources from where the data is downloaded. Default is ``None``
     :type url: str
-    :param data_folder: folder name where the fetched data will be (or already is) saved. Default is ``None``
+    :param data_folder: folder name where the fetched data will be (or already is) saved. Default is ``'.'``
     :type data_folder: str
     :param filename: filename of the file where the fetched data will be (or already is) saved. Default is ``None``
     :type filename: str
@@ -63,7 +63,7 @@ class DownloadRequest:
                  post_values=None, save_response=True, return_data=True, data_type=MimeType.RAW, **properties):
 
         self.url = url
-        self.data_folder = data_folder
+        self.data_folder = data_folder or '.'
         self.filename = filename
         self.headers = headers
         self.post_values = post_values
@@ -104,11 +104,11 @@ class DownloadRequest:
         :param data_folder: folder name where the fetched data will be (or already is) saved.
         :return: str
         """
-        self.data_folder = data_folder
+        self.data_folder = data_folder or '.'
         self._set_file_location()
 
     def _set_file_location(self):
-        if self.data_folder is not None and self.filename is not None:
+        if self.filename is not None:
             self.file_location = os.path.join(self.data_folder, self.filename.lstrip('/'))
 
     def is_downloaded(self):
@@ -117,8 +117,6 @@ class DownloadRequest:
         :return: returns ``True`` if data for this request has already been downloaded and is saved to disk.
         :rtype: bool
         """
-        if self.data_folder is None:
-            return False
         self._set_file_location()
         return os.path.exists(self.file_location)
 
@@ -128,9 +126,7 @@ class DownloadRequest:
         :return: full filename (data folder + filename)
         :rtype: str
         """
-        if self.data_folder:
-            return os.path.join(self.data_folder, self.filename)
-        return None
+        return os.path.join(self.data_folder, self.filename)
 
 
 def download_data(request_list, redownload=False, max_threads=None):


### PR DESCRIPTION
This commit limits the possible values for the data_folder variables in the AwsService, DataRequest, and DownloadRequest classes to non-empty strings. This fixes the error thrown when providing no value for the data_folder argument in AwsProductRequest, and it enforces a consistent state across the classes where data_folder always holds a value that can be used with os.path.join.

Note that joining the empty string with another path is an idempotent operation, whereas joining with the current directory ('.') results in a new path that explicitly references "this directory". That is, joining the empty string with 'bob' results in 'bob', but joining the current directory with 'bob' results in './bob'. The two result paths are equivalent as long as any further path joining happens
via os.path.join (which it should).