### PR TITLE
Fix Travis build on pull requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,5 +14,5 @@ install:
 script:
 - pylint sentinelhub/*.py
 - radon cc sentinelhub/*.py -a -nb
-- 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then pytest --cov ./tests/ --ignore tests\test_ogc.py --ignore tests\test_data_request.py ; fi'
+- 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then pytest --cov ./tests/ --ignore tests/test_ogc.py --ignore tests/test_data_request.py ; fi'
 - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then pytest --cov ./tests/; fi'

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,5 @@ install:
 script:
 - pylint sentinelhub/*.py
 - radon cc sentinelhub/*.py -a -nb
-- pytest --cov
+- 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then pytest --cov ./tests/ --ignore tests\test_ogc.py --ignore tests\test_data_request.py ; fi'
+- 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then pytest --cov ./tests/; fi'


### PR DESCRIPTION
Environment variables needed in some tests are not exposed to build system during pull request builds, due to security reasons. These tests should be skipped in this situation.