### PR TITLE
remove AWS credentials check and set in boto3 only if they are configured

### DIFF
--- a/sentinelhub/download.py
+++ b/sentinelhub/download.py
@@ -278,14 +278,13 @@ def _do_aws_request(request):
     :rtype: dict
     :raises: AwsDownloadFailedException, ValueError
     """
-    if not SHConfig().aws_access_key_id or not SHConfig().aws_secret_access_key:
-        raise ValueError('The requested data is in Requester Pays AWS bucket. In order to download the data please set '
-                         'your access key in command line:\n'
-                         '$ sentinelhub.config --aws_access_key_id <your AWS key> --aws_secret_access_key '
-                         '<your AWS secret key>')
+    if SHConfig().aws_access_key_id and SHConfig().aws_secret_access_key:
+        key_args = dict(aws_access_key_id=SHConfig().aws_access_key_id,
+                        aws_secret_access_key=SHConfig().aws_secret_access_key)
+    else:
+        key_args = {}
     aws_service, _, bucket_name, url_key = request.url.split('/', 3)
-    s3_client = boto3.client(aws_service.strip(':'), aws_access_key_id=SHConfig().aws_access_key_id,
-                             aws_secret_access_key=SHConfig().aws_secret_access_key)
+    s3_client = boto3.client(aws_service.strip(':'), **key_args)
     try:
         return s3_client.get_object(Bucket=bucket_name, Key=url_key, RequestPayer='requester')
     except s3_client.exceptions.NoSuchKey:


### PR DESCRIPTION
This enables retrieval of credentials from the environment as described at:
https://boto3.readthedocs.io/en/latest/guide/configuration.html

For example, boto3 will retrieve credentials from environment variables or the EC2 instance metadata service, allowing us to avoid hardcoding credentials in a configuration file.