### PR TITLE
Use opencv-python-headless over opencv-python

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ requests
 click
 numpy
 matplotlib
-opencv-python==3.4.0.14
+opencv-python-headless==3.4.0.14
 tifffile
 cython
 python-dateutil


### PR DESCRIPTION
More information in https://github.com/sentinel-hub/sentinelhub-py/issues/40.

The current usage of opencv (cv2) in the code are in `download.py`:
https://github.com/sentinel-hub/sentinelhub-py/blob/06f627ad3b55c5aadddd3926f12a3f6a36aa70dd/sentinelhub/download.py#L412

and `io_utils.py`:
https://github.com/sentinel-hub/sentinelhub-py/blob/06f627ad3b55c5aadddd3926f12a3f6a36aa70dd/sentinelhub/io_utils.py#L78
https://github.com/sentinel-hub/sentinelhub-py/blob/06f627ad3b55c5aadddd3926f12a3f6a36aa70dd/sentinelhub/io_utils.py#L93
https://github.com/sentinel-hub/sentinelhub-py/blob/06f627ad3b55c5aadddd3926f12a3f6a36aa70dd/sentinelhub/io_utils.py#L220
https://github.com/sentinel-hub/sentinelhub-py/blob/06f627ad3b55c5aadddd3926f12a3f6a36aa70dd/sentinelhub/io_utils.py#L234

All of which should be possible with the headless package.