### PR TITLE
query on geopedia

### DIFF
--- a/sentinelhub/geopedia.py
+++ b/sentinelhub/geopedia.py
@@ -248,3 +248,12 @@ class GeopediaFeatureIterator(GeopediaService):
         """
         for feature in self:
             yield feature['properties'].get(field, [])
+
+    def add_query(self, query=None):
+        """ Add query, e.g. f12345 = 2015
+
+        :param query: query string
+        :type query: str
+        """
+        if query:
+            self.query['filterExpression'] += ' && ' + query


### PR DESCRIPTION
use filterExpression to query directly on geopedia (on top of bbox)