### PR TITLE
Docs/cleanup

### DIFF
--- a/docs/source/areas.rst
+++ b/docs/source/areas.rst
@@ -1,7 +1,7 @@
 areas
 =====
 
-Module for working with large geographical areas.
+Module for working with large geographical areas
 
 .. module:: sentinelhub.areas
 .. autoclass:: AreaSplitter

--- a/docs/source/aws.rst
+++ b/docs/source/aws.rst
@@ -1,12 +1,6 @@
 aws
 ===
 
-Module for obtaining data from Amazon Web Service.
-
-.. module:: sentinelhub.aws
-.. autoclass:: AwsService
+.. automodule:: sentinelhub.aws
     :members:
-.. autoclass:: AwsProduct
-    :members:
-.. autoclass:: AwsTile
-    :members:
+    :show-inheritance:

--- a/docs/source/aws_safe.rst
+++ b/docs/source/aws_safe.rst
@@ -1,10 +1,6 @@
 aws_safe
 ========
 
-Module for creating .SAFE structure with data from AWS.
-
-.. module:: sentinelhub.aws_safe
-.. autoclass:: SafeProduct
+.. automodule:: sentinelhub.aws_safe
     :members:
-.. autoclass:: SafeTile
-    :members:
+    :show-inheritance:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -60,6 +60,9 @@ extensions = [
 # Both the class’ and the __init__ method’s docstring are concatenated and inserted.
 autoclass_content = 'both'
 
+# Content is in the same order as in module
+autodoc_member_order = 'bysource'
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 

--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -1,8 +1,6 @@
 config
 ======
 
-Module to collect configuration data from config.json.
-
-.. module:: sentinelhub.config
-.. autoclass:: SHConfig
+.. automodule:: sentinelhub.config
     :members:
+    :show-inheritance:

--- a/docs/source/constants.rst
+++ b/docs/source/constants.rst
@@ -1,19 +1,6 @@
 constants
-============
+=========
 
-Module defining constants and enumerate types used in the package.
-
-.. module:: sentinelhub.constants
-.. autoclass:: PackageProps
-.. autoclass:: ServiceType
+.. automodule:: sentinelhub.constants
     :members:
-.. autoclass:: DataSource
-    :members:
-.. autoclass:: MimeType
-    :members:
-.. autoclass:: CustomUrlParam
-    :members:
-.. autoclass:: RequestType
-.. autoclass:: OgcConstants
-.. autoclass:: AwsConstants
-.. autoclass:: EsaSafeType
+    :show-inheritance:

--- a/docs/source/data_request.rst
+++ b/docs/source/data_request.rst
@@ -1,28 +1,6 @@
 data_request
-===============
+============
 
-Main module to handle data requests.
-
-.. module:: sentinelhub.data_request
-.. autoclass:: DataRequest
+.. automodule:: sentinelhub.data_request
     :members:
-.. autoclass:: OgcRequest
-    :members:
-.. autoclass:: WmsRequest
-    :members:
-.. autoclass:: WcsRequest
-    :members:
-.. autoclass:: FisRequest
-    :members:
-.. autoclass:: GeopediaRequest
-    :members:
-.. autoclass:: GeopediaWmsRequest
-    :members:
-.. autoclass:: AwsRequest
-    :members:
-.. autoclass:: AwsProductRequest
-    :members:
-.. autoclass:: AwsTileRequest
-    :members:
-.. autofunction:: get_safe_format
-.. autofunction:: download_safe_format
+    :show-inheritance:

--- a/docs/source/download.rst
+++ b/docs/source/download.rst
@@ -1,14 +1,6 @@
 download
 ========
 
-Module for downloading data
-
-.. module:: sentinelhub.download
-.. autoclass:: DownloadRequest
+.. automodule:: sentinelhub.download
     :members:
-.. autofunction:: download_data
-.. autofunction:: execute_download_request
-.. autofunction:: decode_data
-.. autofunction:: decode_image
-.. autofunction:: get_json
-.. autofunction:: get_xml
+    :show-inheritance:

--- a/docs/source/fis.rst
+++ b/docs/source/fis.rst
@@ -1,8 +1,6 @@
 fis
 ======
 
-Module for working with Sentinel Hub FIS service
-
-.. module:: sentinelhub.fis
-.. autoclass:: FisService
+.. automodule:: sentinelhub.fis
     :members:
+    :show-inheritance:

--- a/docs/source/geo_utils.rst
+++ b/docs/source/geo_utils.rst
@@ -1,19 +1,6 @@
 geo_utils
 =========
 
-Module for manipulation of geographical information.
-
-.. module:: sentinelhub.geo_utils
-.. autofunction:: bbox_to_dimensions
-.. autofunction:: bbox_to_resolution
-.. autofunction:: get_image_dimension
-.. autofunction:: to_utm_bbox
-.. autofunction:: get_utm_bbox
-.. autofunction:: wgs84_to_utm
-.. autofunction:: to_wgs84
-.. autofunction:: utm_to_pixel
-.. autofunction:: pixel_to_utm
-.. autofunction:: wgs84_to_pixel
-.. autofunction:: get_utm_crs
-.. autofunction:: transform_point
-.. autofunction:: transform_bbox
+.. automodule:: sentinelhub.geo_utils
+    :members:
+    :show-inheritance:

--- a/docs/source/geometry.rst
+++ b/docs/source/geometry.rst
@@ -1,14 +1,6 @@
 geometry
 ========
 
-Module implementing geometry classes.
-
-.. module:: sentinelhub.geometry
-.. autoclass:: BaseGeometry
+.. automodule:: sentinelhub.geometry
     :members:
-.. autoclass:: BBox
-    :members:
-.. autoclass:: Geometry
-    :members:
-.. autoclass:: BBoxCollection
-    :members:
+    :show-inheritance:

--- a/docs/source/geopedia.rst
+++ b/docs/source/geopedia.rst
@@ -1,16 +1,6 @@
 geopedia
 ========
 
-Module for working with Geopedia
-
-.. module:: sentinelhub.geopedia
-.. autoclass:: GeopediaService
+.. automodule:: sentinelhub.geopedia
     :members:
-.. autoclass:: GeopediaSession
-    :members:
-.. autoclass:: GeopediaWmsService
-    :members:
-.. autoclass:: GeopediaImageService
-    :members:
-.. autoclass:: GeopediaFeatureIterator
-    :members:
+    :show-inheritance:

--- a/docs/source/io_utils.rst
+++ b/docs/source/io_utils.rst
@@ -1,26 +1,6 @@
 io_utils
 ========
 
-Utility functions to read/write image data from/to file.
-
-.. module:: sentinelhub.io_utils
-.. autofunction:: read_data
-.. autofunction:: read_tiff_image
-.. autofunction:: read_jp2_image
-.. autofunction:: read_image
-.. autofunction:: read_text
-.. autofunction:: read_csv
-.. autofunction:: read_json
-.. autofunction:: read_xml
-.. autofunction:: read_numpy
-.. autofunction:: write_data
-.. autofunction:: write_tiff_image
-.. autofunction:: write_jp2_image
-.. autofunction:: write_image
-.. autofunction:: write_text
-.. autofunction:: write_csv
-.. autofunction:: write_json
-.. autofunction:: write_xml
-.. autofunction:: write_numpy
-.. autofunction:: get_data_format
-.. autofunction:: get_jp2_bit_depth
+.. automodule:: sentinelhub.io_utils
+    :members:
+    :show-inheritance:

--- a/docs/source/ogc.rst
+++ b/docs/source/ogc.rst
@@ -1,12 +1,6 @@
 ogc
-======
+===
 
-Module for working with OGC services
-
-.. module:: sentinelhub.ogc
-.. autoclass:: OgcService
+.. automodule:: sentinelhub.ogc
     :members:
-.. autoclass:: OgcImageService
-    :members:
-.. autoclass:: WebFeatureService
-    :members:
+    :show-inheritance:

--- a/docs/source/opensearch.rst
+++ b/docs/source/opensearch.rst
@@ -1,14 +1,6 @@
 opensearch
 ==========
 
-Module for communication with http://opensearch.sentinel-hub.com/resto/api
-
-For more search parameters check: http://opensearch.sentinel-hub.com/resto/api/collections/Sentinel2/describe.xml
-
-.. module:: sentinelhub.opensearch
-.. autofunction:: get_tile_info_id
-.. autofunction:: get_tile_info
-.. autofunction:: get_area_info
-.. autofunction:: get_area_dates
-.. autofunction:: reduce_by_maxcc
-.. autofunction:: search_iter
+.. automodule:: sentinelhub.opensearch
+    :members:
+    :show-inheritance:

--- a/docs/source/os_utils.rst
+++ b/docs/source/os_utils.rst
@@ -1,14 +1,6 @@
 os_utils
 ========
 
-Wrapper functions to list, create, rename, and remove files and directories. 
-
-.. module:: sentinelhub.os_utils
-.. autofunction:: get_content_list
-.. autofunction:: get_folder_list
-.. autofunction:: get_file_list
-.. autofunction:: create_parent_folder
-.. autofunction:: make_folder
-.. autofunction:: rename
-.. autofunction:: size
-.. autofunction:: sys_is_windows
+.. automodule:: sentinelhub.os_utils
+    :members:
+    :show-inheritance:

--- a/docs/source/test_utils.rst
+++ b/docs/source/test_utils.rst
@@ -1,10 +1,6 @@
 test_utils
 ==========
 
-Utility tools for writing unit tests for packages which rely on `sentinelhub-py`.
-
-.. module:: sentinelhub.test_utils
-.. autoclass:: TestSentinelHub
+.. automodule:: sentinelhub.test_utils
     :members:
-.. autoclass:: TestCaseContainer
-    :members:
+    :show-inheritance:

--- a/docs/source/time_utils.rst
+++ b/docs/source/time_utils.rst
@@ -1,15 +1,6 @@
 time_utils
 ==========
 
-Utility functions for processing time/date formats.
-
-.. module:: sentinelhub.time_utils
-.. autofunction:: get_dates_in_range
-.. autofunction:: next_date
-.. autofunction:: prev_date
-.. autofunction:: iso_to_datetime
-.. autofunction:: datetime_to_iso
-.. autofunction:: get_current_date
-.. autofunction:: is_valid_time
-.. autofunction:: parse_time
-.. autofunction:: parse_time_interval
+.. automodule:: sentinelhub.time_utils
+    :members:
+    :show-inheritance:

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -2,4 +2,4 @@ sphinx
 sphinx_rtd_theme
 nbsphinx
 matplotlib
-jupyter
+ipython

--- a/sentinelhub/areas.py
+++ b/sentinelhub/areas.py
@@ -23,7 +23,7 @@ class AreaSplitter(ABC):
     :param crs: Coordinate reference system of the shapes in `shape_list`
     :type crs: CRS
     :param reduce_bbox_sizes: If `True` it will reduce the sizes of bounding boxes so that they will tightly fit the
-    given geometry in `shape_list`.
+        given geometry in `shape_list`.
     :type reduce_bbox_sizes: bool
     """
     def __init__(self, shape_list, crs, reduce_bbox_sizes=False):
@@ -82,7 +82,7 @@ class AreaSplitter(ABC):
         """ Returns a list of bounding boxes that are the result of the split
 
         :param crs: Coordinate reference system in which the bounding boxes should be returned. If `None` the CRS will
-                    be the default CRS of the splitter.
+            be the default CRS of the splitter.
         :type crs: CRS or None
         :param buffer: A percentage of each BBox size increase. This will cause neighbouring bounding boxes to overlap.
         :type buffer: float or None
@@ -135,7 +135,7 @@ class AreaSplitter(ABC):
         """ Returns a bounding box of the entire area
 
         :param crs: Coordinate reference system in which the bounding box should be returned. If `None` the CRS will
-                    be the default CRS of the splitter.
+            be the default CRS of the splitter.
         :type crs: CRS or None
         :return: A bounding box of the area defined by the `shape_list`
         :rtype: BBox

--- a/sentinelhub/areas.py
+++ b/sentinelhub/areas.py
@@ -1,6 +1,7 @@
 """
 Module for working with large geographical areas
 """
+
 import itertools
 from abc import ABC, abstractmethod
 
@@ -14,15 +15,15 @@ from .ogc import WebFeatureService
 
 
 class AreaSplitter(ABC):
-    """
-    Abstract class for splitter classes. It implements common methods used for splitting large area into smaller parts.
+    """ Abstract class for splitter classes. It implements common methods used for splitting large area into smaller
+    parts.
 
     :param shape_list: A list of geometrical shapes describing the area of interest
     :type shape_list: list(shapely.geometry.multipolygon.MultiPolygon or shapely.geometry.polygon.Polygon)
     :param crs: Coordinate reference system of the shapes in `shape_list`
     :type crs: CRS
-    :param reduce_bbox_sizes: If True it will reduce the sizes of bounding boxes so that they will tightly fit the given
-           geometry in `shape_list`.
+    :param reduce_bbox_sizes: If `True` it will reduce the sizes of bounding boxes so that they will tightly fit the
+    given geometry in `shape_list`.
     :type reduce_bbox_sizes: bool
     """
     def __init__(self, shape_list, crs, reduce_bbox_sizes=False):
@@ -51,6 +52,8 @@ class AreaSplitter(ABC):
 
     @staticmethod
     def _parse_shape(shape, crs):
+        """ Helper method for parsing input shapes
+        """
         if isinstance(shape, (Polygon, MultiPolygon)):
             return shape
         if isinstance(shape, BaseGeometry):
@@ -60,7 +63,7 @@ class AreaSplitter(ABC):
 
     @staticmethod
     def _join_shape_list(shape_list):
-        """Joins a list of shapes together into one shape
+        """ Joins a list of shapes together into one shape
 
         :param shape_list: A list of geometrical shapes describing the area of interest
         :type shape_list: list(shapely.geometry.multipolygon.MultiPolygon or shapely.geometry.polygon.Polygon)
@@ -71,14 +74,14 @@ class AreaSplitter(ABC):
 
     @abstractmethod
     def _make_split(self):
-        """The abstract method where the splitting will happen
+        """ The abstract method where the splitting will happen
         """
         raise NotImplementedError
 
     def get_bbox_list(self, crs=None, buffer=None, reduce_bbox_sizes=None):
-        """Returns a list of bounding boxes that are the result of the split
+        """ Returns a list of bounding boxes that are the result of the split
 
-        :param crs: Coordinate reference system in which the bounding boxes should be returned. If None the CRS will
+        :param crs: Coordinate reference system in which the bounding boxes should be returned. If `None` the CRS will
                     be the default CRS of the splitter.
         :type crs: CRS or None
         :param buffer: A percentage of each BBox size increase. This will cause neighbouring bounding boxes to overlap.
@@ -103,7 +106,7 @@ class AreaSplitter(ABC):
         return bbox_list
 
     def get_geometry_list(self):
-        """For each bounding box an intersection with the shape of entire given area is calculated. CRS of the returned
+        """ For each bounding box an intersection with the shape of entire given area is calculated. CRS of the returned
         shapes is the same as CRS of the given area.
 
         :return: List of polygons or multipolygons corresponding to the order of bounding boxes
@@ -112,7 +115,7 @@ class AreaSplitter(ABC):
         return [self._intersection_area(bbox) for bbox in self.bbox_list]
 
     def get_info_list(self):
-        """Returns a list of dictionaries containing information about bounding boxes obtained in split. The order in
+        """ Returns a list of dictionaries containing information about bounding boxes obtained in split. The order in
         the list matches the order of the list of bounding boxes.
 
         :return: List of dictionaries
@@ -121,7 +124,7 @@ class AreaSplitter(ABC):
         return self.info_list
 
     def get_area_shape(self):
-        """Returns a single shape of entire area described with `shape_list` parameter
+        """ Returns a single shape of entire area described with `shape_list` parameter
 
         :return: A multipolygon which is a union of shapes describing the area
         :rtype: shapely.geometry.multipolygon.MultiPolygon
@@ -129,9 +132,9 @@ class AreaSplitter(ABC):
         return self.area_shape
 
     def get_area_bbox(self, crs=None):
-        """Returns a bounding box of the entire area
+        """ Returns a bounding box of the entire area
 
-        :param crs: Coordinate reference system in which the bounding box should be returned. If None the CRS will
+        :param crs: Coordinate reference system in which the bounding box should be returned. If `None` the CRS will
                     be the default CRS of the splitter.
         :type crs: CRS or None
         :return: A bounding box of the area defined by the `shape_list`
@@ -148,17 +151,17 @@ class AreaSplitter(ABC):
         return bbox.transform(crs)
 
     def _intersects_area(self, bbox):
-        """Checks if the bounding box intersects the entire area
+        """ Checks if the bounding box intersects the entire area
 
         :param bbox: A bounding box
         :type bbox: BBox
-        :return: True if bbox intersects the entire area else False
+        :return: `True` if bbox intersects the entire area else False
         :rtype: bool
         """
         return self._bbox_to_area_polygon(bbox).intersects(self.area_shape)
 
     def _intersection_area(self, bbox):
-        """Calculates the intersection of a given bounding box and the entire area
+        """ Calculates the intersection of a given bounding box and the entire area
 
         :param bbox: A bounding box
         :type bbox: BBox
@@ -168,7 +171,7 @@ class AreaSplitter(ABC):
         return self._bbox_to_area_polygon(bbox).intersection(self.area_shape)
 
     def _bbox_to_area_polygon(self, bbox):
-        """Transforms bounding box into a polygon object in the area CRS.
+        """ Transforms bounding box into a polygon object in the area CRS.
 
         :param bbox: A bounding box
         :type bbox: BBox
@@ -179,15 +182,15 @@ class AreaSplitter(ABC):
         return projected_bbox.geometry
 
     def _reduce_sizes(self, bbox_list):
-        """Reduces sizes of bounding boxes
+        """ Reduces sizes of bounding boxes
         """
         return [BBox(self._intersection_area(bbox).bounds, self.crs).transform(bbox.crs) for bbox in bbox_list]
 
 
 class BBoxSplitter(AreaSplitter):
-    """A tool that splits the given area into smaller parts. Given the area it calculates its bounding box and splits it
-    into smaller bounding boxes of equal size. Then it filters out the bounding boxes that do not intersect the area. If
-    specified by user it can also reduce the sizes of the remaining bounding boxes to best fit the area.
+    """ A tool that splits the given area into smaller parts. Given the area it calculates its bounding box and splits
+    it into smaller bounding boxes of equal size. Then it filters out the bounding boxes that do not intersect the
+    area. If specified by user it can also reduce the sizes of the remaining bounding boxes to best fit the area.
 
     :param shape_list: A list of geometrical shapes describing the area of interest
     :type shape_list: list(shapely.geometry.multipolygon.MultiPolygon or shapely.geometry.polygon.Polygon)
@@ -197,8 +200,8 @@ class BBoxSplitter(AreaSplitter):
                         tuple of the form `(n, m)` which means the area bounding box will be split into `n` columns and
                         `m` rows. It can also be a single integer `n` which is the same as `(n, n)`.
     :type split_shape: int or (int, int)
-    :param reduce_bbox_sizes: If True it will reduce the sizes of bounding boxes so that they will tightly fit the given
-           area geometry from `shape_list`.
+    :param reduce_bbox_sizes: If `True` it will reduce the sizes of bounding boxes so that they will tightly fit
+        the given area geometry from `shape_list`.
     :type reduce_bbox_sizes: bool
     """
     def __init__(self, shape_list, crs, split_shape, **kwargs):
@@ -210,7 +213,7 @@ class BBoxSplitter(AreaSplitter):
 
     @staticmethod
     def _parse_split_shape(split_shape):
-        """Parses the parameter `split_shape`
+        """ Parses the parameter `split_shape`
 
         :param split_shape: The parameter `split_shape` from class initialization
         :type split_shape: int or (int, int)
@@ -245,9 +248,9 @@ class BBoxSplitter(AreaSplitter):
 
 
 class OsmSplitter(AreaSplitter):
-    """A tool that splits the given area into smaller parts. For the splitting it uses Open Street Map (OSM) grid on the
-    specified zoom level. It calculates bounding boxes of all OSM tiles that intersect the area. If specified by user
-    it can also reduce the sizes of the remaining bounding boxes to best fit the area.
+    """ A tool that splits the given area into smaller parts. For the splitting it uses Open Street Map (OSM) grid on
+    the specified zoom level. It calculates bounding boxes of all OSM tiles that intersect the area. If specified by
+    user it can also reduce the sizes of the remaining bounding boxes to best fit the area.
 
     :param shape_list: A list of geometrical shapes describing the area of interest
     :type shape_list: list(shapely.geometry.multipolygon.MultiPolygon or shapely.geometry.polygon.Polygon)
@@ -255,8 +258,8 @@ class OsmSplitter(AreaSplitter):
     :type crs: CRS
     :param zoom_level: A zoom level defined by OSM. Level 0 is entire world, level 1 splits the world into 4 parts, etc.
     :type zoom_level: int
-    :param reduce_bbox_sizes: If True it will reduce the sizes of bounding boxes so that they will tightly fit the given
-           area geometry from `shape_list`.
+    :param reduce_bbox_sizes: If `True` it will reduce the sizes of bounding boxes so that they will tightly fit
+        the given area geometry from `shape_list`.
     :type reduce_bbox_sizes: bool
     """
     POP_WEB_MAX = transform_point((180, 0), CRS.WGS84, CRS.POP_WEB)[0]
@@ -282,7 +285,7 @@ class OsmSplitter(AreaSplitter):
             self.bbox_list[i] = bbox.transform(self.crs)
 
     def _check_area_bbox(self):
-        """The method checks if the area bounding box is completely inside the OSM grid. That means that its latitudes
+        """ The method checks if the area bounding box is completely inside the OSM grid. That means that its latitudes
         must be contained in the interval (-85.0511, 85.0511)
 
         :raises: ValueError
@@ -293,7 +296,7 @@ class OsmSplitter(AreaSplitter):
                                  '(-85.0511, 85.0511)')
 
     def get_world_bbox(self):
-        """Creates a bounding box of the entire world in EPSG: 3857
+        """ Creates a bounding box of the entire world in EPSG: 3857
 
         :return: Bounding box of entire world
         :rtype: BBox
@@ -301,7 +304,7 @@ class OsmSplitter(AreaSplitter):
         return BBox((-self.POP_WEB_MAX, -self.POP_WEB_MAX, self.POP_WEB_MAX, self.POP_WEB_MAX), crs=CRS.POP_WEB)
 
     def _recursive_split(self, bbox, zoom_level, column, row):
-        """Method that recursively creates bounding boxes of OSM grid that intersect the area.
+        """ Method that recursively creates bounding boxes of OSM grid that intersect the area.
 
         :param bbox: Bounding box
         :type bbox: BBox
@@ -345,11 +348,11 @@ class TileSplitter(AreaSplitter):
     :type split_shape: int or (int, int)
     :param data_source: Source of requested satellite data. Default is Sentinel-2 L1C data.
     :type data_source: sentinelhub.constants.DataSource
-    :param instance_id: User's Sentinel Hub instance id. If ``None`` the instance id is taken from the ``config.json``
+    :param instance_id: User's Sentinel Hub instance id. If `None` the instance id is taken from the ``config.json``
                         configuration file.
     :type instance_id: str
-    :param reduce_bbox_sizes: If True it will reduce the sizes of bounding boxes so that they will tightly fit the given
-           area geometry from `shape_list`.
+    :param reduce_bbox_sizes: If `True` it will reduce the sizes of bounding boxes so that they will tightly fit the
+        given area geometry from `shape_list`.
     :type reduce_bbox_sizes: bool
     """
     def __init__(self, shape_list, crs, time_interval, tile_split_shape=1, data_source=DataSource.SENTINEL2_L1C,
@@ -407,7 +410,7 @@ class TileSplitter(AreaSplitter):
                     self.info_list.append(info)
 
     def get_tile_dict(self):
-        """Returns the dictionary of satellite tiles intersecting the area geometry. For each tile they contain info
+        """ Returns the dictionary of satellite tiles intersecting the area geometry. For each tile they contain info
         about their bounding box and lists of acquisitions and geometries
 
         :return: Dictionary containing info about tiles intersecting the area
@@ -430,8 +433,8 @@ class CustomGridSplitter(AreaSplitter):
         will be split. It can be a tuple of the form `(n, m)` which means the tile bounding boxes will be
         split into `n` columns and `m` rows. It can also be a single integer `n` which is the same as `(n, n)`.
     :type bbox_split_shape: int or (int, int)
-    :param reduce_bbox_sizes: If True it will reduce the sizes of bounding boxes so that they will tightly fit the given
-           geometry in `shape_list`.
+    :param reduce_bbox_sizes: If `True` it will reduce the sizes of bounding boxes so that they will tightly fit
+        the given geometry in `shape_list`.
     :type reduce_bbox_sizes: bool
     """
     def __init__(self, shape_list, crs, bbox_grid, bbox_split_shape=1, **kwargs):

--- a/sentinelhub/aws.py
+++ b/sentinelhub/aws.py
@@ -73,8 +73,7 @@ class AwsService(ABC):
         return band_list
 
     def _parse_metafiles(self, metafile_input):
-        """
-        Parses class input and verifies metadata file names.
+        """ Parses class input and verifies metadata file names.
 
         :param metafile_input: class input parameter `metafiles`
         :type metafile_input: str or list(str) or None
@@ -117,7 +116,7 @@ class AwsService(ABC):
         return '{}/{}/'.format(base_url, aws_bucket)
 
     def get_safe_type(self):
-        """Determines the type of ESA product.
+        """ Determines the type of ESA product.
 
         In 2016 ESA changed structure and naming of data. Therefore the class must
         distinguish between old product type and compact (new) product type.
@@ -148,7 +147,7 @@ class AwsService(ABC):
         return self._read_baseline_from_info()
 
     def _read_baseline_from_info(self):
-        """Tries to find and return baseline number from either tileInfo or productInfo file.
+        """ Tries to find and return baseline number from either tileInfo or productInfo file.
 
         :return: Baseline ID
         :rtype: str
@@ -162,8 +161,7 @@ class AwsService(ABC):
 
     @staticmethod
     def url_to_tile(url):
-        """
-        Extracts tile name, date and AWS index from tile url on AWS.
+        """ Extracts tile name, date and AWS index from tile url on AWS.
 
         :param url: class input parameter 'metafiles'
         :type url: str
@@ -176,8 +174,7 @@ class AwsService(ABC):
         return name, date, int(info[-1])
 
     def sort_download_list(self):
-        """
-        Method for sorting the list of download requests. Band images have priority before metadata files. If bands
+        """ Method for sorting the list of download requests. Band images have priority before metadata files. If bands
         images or metadata files are specified with a list they will be sorted in the same order as in the list.
         Otherwise they will be sorted alphabetically (band B8A will be between B08 and B09).
         """
@@ -193,8 +190,7 @@ class AwsService(ABC):
         self.download_list.sort(key=aws_sort_function)
 
     def structure_recursion(self, struct, folder):
-        """
-        From nested dictionaries representing .SAFE structure it recursively extracts all the files that need to be
+        """ From nested dictionaries representing .SAFE structure it recursively extracts all the files that need to be
         downloaded and stores them into class attribute `download_list`.
 
         :param struct: nested dictionaries representing a part of .SAFE structure
@@ -243,7 +239,7 @@ class AwsService(ABC):
 
     @staticmethod
     def add_file_extension(filename, data_format=None, remove_path=False):
-        """Joins filename and corresponding file extension if it has one.
+        """ Joins filename and corresponding file extension if it has one.
 
         :param filename: Name of the file without extension
         :type filename: str
@@ -265,7 +261,7 @@ class AwsService(ABC):
         return '{}.{}'.format(filename.replace('*', ''), data_format.value)
 
     def has_reports(self):
-        """Products created with baseline 2.06 and greater (and some products with baseline 2.05) should have quality
+        """ Products created with baseline 2.06 and greater (and some products with baseline 2.05) should have quality
         report files
 
         :return: `True` if the product has report xml files and `False` otherwise
@@ -274,7 +270,7 @@ class AwsService(ABC):
         return self.baseline > '02.05' or (self.baseline == '02.05' and self.date >= '2017-10-12')  # Not sure
 
     def is_early_compact_l2a(self):
-        """Check if product is early version of compact L2A product
+        """ Check if product is early version of compact L2A product
 
         :return: `True` if product is early version of compact L2A product and `False` otherwise
         :rtype: bool
@@ -285,21 +281,22 @@ class AwsService(ABC):
 
 class AwsProduct(AwsService):
     """ Service class for Sentinel-2 product on AWS
-
-    :param product_id: ESA ID of the product
-    :type product_id: str
-    :param tile_list: list of tile names
-    :type tile_list: list(str) or None
-    :param parent_folder: location of the directory where the fetched data will be saved.
-    :type parent_folder: str
-    :param bands: List of Sentinel-2 bands for request. If parameter is set to `None` all bands will be used.
-    :type bands: list(str) or None
-    :param metafiles: List of additional metafiles available on AWS
-                      (e.g. ``['metadata', 'tileInfo', 'preview/B01', 'TCI']``).
-                      If parameter is set to `None` the list will be set automatically.
-    :type metafiles: list(str) or None
     """
     def __init__(self, product_id, tile_list=None, **kwargs):
+        """
+        :param product_id: ESA ID of the product
+        :type product_id: str
+        :param tile_list: list of tile names
+        :type tile_list: list(str) or None
+        :param parent_folder: location of the directory where the fetched data will be saved.
+        :type parent_folder: str
+        :param bands: List of Sentinel-2 bands for request. If parameter is set to `None` all bands will be used.
+        :type bands: list(str) or None
+        :param metafiles: List of additional metafiles available on AWS
+                          (e.g. ``['metadata', 'tileInfo', 'preview/B01', 'TCI']``).
+                          If parameter is set to `None` the list will be set automatically.
+        :type metafiles: list(str) or None
+        """
         self.product_id = product_id.split('.')[0]
         self.tile_list = self.parse_tile_list(tile_list)
 
@@ -316,8 +313,7 @@ class AwsProduct(AwsService):
 
     @staticmethod
     def parse_tile_list(tile_input):
-        """
-        Parses class input and verifies band names.
+        """ Parses class input and verifies band names.
 
         :param tile_input: class input parameter `tile_list`
         :type tile_input: str or list(str)
@@ -336,8 +332,7 @@ class AwsProduct(AwsService):
         return tile_list
 
     def get_requests(self):
-        """
-        Creates product structure and returns list of files for download.
+        """ Creates product structure and returns list of files for download.
 
         :return: List of download requests and list of empty folders that need to be created
         :rtype: (list(download.DownloadRequest), list(str))
@@ -359,7 +354,7 @@ class AwsProduct(AwsService):
         return self.download_list, self.folder_list
 
     def get_data_source(self):
-        """The method determines data source from product ID.
+        """ The method determines data source from product ID.
 
         :return: Data source of the product
         :rtype: DataSource
@@ -387,8 +382,7 @@ class AwsProduct(AwsService):
         return '-'.join(date_part.lstrip('0') for date_part in date)
 
     def get_url(self, filename, data_format=None):
-        """
-        Creates url of file location on AWS.
+        """ Creates url of file location on AWS.
 
         :param filename: name of file
         :type filename: str
@@ -404,8 +398,7 @@ class AwsProduct(AwsService):
         return '{}/{}'.format(product_url, self.add_file_extension(filename, data_format))
 
     def get_product_url(self, force_http=False):
-        """
-        Creates base url of product location on AWS.
+        """ Creates base url of product location on AWS.
 
         :param force_http: `True` if HTTP base URL should be used and `False` otherwise
         :type force_http: str
@@ -416,8 +409,7 @@ class AwsProduct(AwsService):
         return '{}products/{}/{}'.format(base_url, self.date.replace('-', '/'), self.product_id)
 
     def get_tile_url(self, tile_info):
-        """
-        Collects tile url from `productInfo.json` file.
+        """ Collects tile url from `productInfo.json` file.
 
         :param tile_info: information about tile from `productInfo.json`
         :type tile_info: dict
@@ -427,8 +419,7 @@ class AwsProduct(AwsService):
         return '{}/{}'.format(self.base_url, tile_info['path'])
 
     def get_filepath(self, filename):
-        """
-        Creates file path for the file.
+        """ Creates file path for the file.
 
         :param filename: name of the file
         :type filename: str
@@ -440,29 +431,30 @@ class AwsProduct(AwsService):
 
 class AwsTile(AwsService):
     """ Service class for Sentinel-2 product on AWS
-
-    :param tile: Tile name (e.g. 'T10UEV')
-    :type tile: str
-    :param time: Tile sensing time in ISO8601 format
-    :type time: str
-    :param aws_index: There exist Sentinel-2 tiles with the same tile and time parameter. Therefore each tile on AWS
-                      also has an index which is visible in their url path. If ``aws_index`` is set to `None` the
-                      class will try to find the index automatically. If there will be multiple choices it will choose
-                      the lowest index and inform the user.
-    :type aws_index: int or None
-    :param data_source: Source of requested AWS data. Supported sources are Sentinel-2 L1C and Sentinel-2 L2A, default
-                        is Sentinel-2 L1C data.
-    :type data_source: constants.DataSource
-    :param parent_folder: folder where the fetched data will be saved.
-    :type parent_folder: str
-    :param bands: List of Sentinel-2 bands for request. If parameter is set to `None` all bands will be used.
-    :type bands: list(str) or None
-    :param metafiles: List of additional metafiles available on AWS
-                      (e.g. ``['metadata', 'tileInfo', 'preview/B01', 'TCI']``).
-                      If parameter is set to `None` the list will be set automatically.
-    :type metafiles: list(str) or None
     """
     def __init__(self, tile_name, time, aws_index=None, data_source=DataSource.SENTINEL2_L1C, **kwargs):
+        """
+        :param tile: Tile name (e.g. 'T10UEV')
+        :type tile: str
+        :param time: Tile sensing time in ISO8601 format
+        :type time: str
+        :param aws_index: There exist Sentinel-2 tiles with the same tile and time parameter. Therefore each tile on AWS
+            also has an index which is visible in their url path. If ``aws_index`` is set to `None` the
+            class will try to find the index automatically. If there will be multiple choices it will choose
+            the lowest index and inform the user.
+        :type aws_index: int or None
+        :param data_source: Source of requested AWS data. Supported sources are Sentinel-2 L1C and Sentinel-2 L2A,
+            default is Sentinel-2 L1C data.
+        :type data_source: constants.DataSource
+        :param parent_folder: folder where the fetched data will be saved.
+        :type parent_folder: str
+        :param bands: List of Sentinel-2 bands for request. If parameter is set to `None` all bands will be used.
+        :type bands: list(str) or None
+        :param metafiles: List of additional metafiles available on AWS
+                          (e.g. ``['metadata', 'tileInfo', 'preview/B01', 'TCI']``).
+                          If parameter is set to `None` the list will be set automatically.
+        :type metafiles: list(str) or None
+        """
         self.tile_name = self.parse_tile_name(tile_name)
         self.datetime = self.parse_datetime(time)
         self.date = self.datetime.split('T')[0]

--- a/sentinelhub/aws.py
+++ b/sentinelhub/aws.py
@@ -18,17 +18,18 @@ LOGGER = logging.getLogger(__name__)
 
 class AwsService(ABC):
     """ Amazon Web Service (AWS) base class
-
-    :param parent_folder: Folder where the fetched data will be saved.
-    :type parent_folder: str
-    :param bands: List of Sentinel-2 bands for request. If parameter is set to ``None`` all bands will be used.
-    :type bands: list(str) or None
-    :param metafiles: List of additional metafiles available on AWS
-                      (e.g. ``['metadata', 'tileInfo', 'preview/B01', 'TCI']``).
-                      If parameter is set to ``None`` the list will be set automatically.
-    :type metafiles: list(str) or None
     """
     def __init__(self, parent_folder='', bands=None, metafiles=None):
+        """
+        :param parent_folder: Folder where the fetched data will be saved.
+        :type parent_folder: str
+        :param bands: List of Sentinel-2 bands for request. If parameter is set to `None` all bands will be used.
+        :type bands: list(str) or None
+        :param metafiles: List of additional metafiles available on AWS
+                          (e.g. ``['metadata', 'tileInfo', 'preview/B01', 'TCI']``).
+                          If parameter is set to `None` the list will be set automatically.
+        :type metafiles: list(str) or None
+        """
         self.parent_folder = parent_folder
         self.bands = self._parse_bands(bands)
         self.metafiles = self._parse_metafiles(metafiles)
@@ -246,9 +247,9 @@ class AwsService(ABC):
 
         :param filename: Name of the file without extension
         :type filename: str
-        :param data_format: format of file, if None it will be set automatically
+        :param data_format: format of file, if `None` it will be set automatically
         :type data_format: constants.MimeType or None
-        :param remove_path: True if the path in filename string should be removed
+        :param remove_path: `True` if the path in filename string should be removed
         :type remove_path: bool
         :return: Name of the file with extension
         :rtype: str
@@ -267,7 +268,7 @@ class AwsService(ABC):
         """Products created with baseline 2.06 and greater (and some products with baseline 2.05) should have quality
         report files
 
-        :return: True if the product has report xml files and False otherwise
+        :return: `True` if the product has report xml files and `False` otherwise
         :rtype: bool
         """
         return self.baseline > '02.05' or (self.baseline == '02.05' and self.date >= '2017-10-12')  # Not sure
@@ -275,7 +276,7 @@ class AwsService(ABC):
     def is_early_compact_l2a(self):
         """Check if product is early version of compact L2A product
 
-        :return: True if product is early version of compact L2A product and False otherwise
+        :return: `True` if product is early version of compact L2A product and `False` otherwise
         :rtype: bool
         """
         return self.data_source is DataSource.SENTINEL2_L2A and self.safe_type is EsaSafeType.COMPACT_TYPE and \
@@ -291,11 +292,11 @@ class AwsProduct(AwsService):
     :type tile_list: list(str) or None
     :param parent_folder: location of the directory where the fetched data will be saved.
     :type parent_folder: str
-    :param bands: List of Sentinel-2 bands for request. If parameter is set to ``None`` all bands will be used.
+    :param bands: List of Sentinel-2 bands for request. If parameter is set to `None` all bands will be used.
     :type bands: list(str) or None
     :param metafiles: List of additional metafiles available on AWS
                       (e.g. ``['metadata', 'tileInfo', 'preview/B01', 'TCI']``).
-                      If parameter is set to ``None`` the list will be set automatically.
+                      If parameter is set to `None` the list will be set automatically.
     :type metafiles: list(str) or None
     """
     def __init__(self, product_id, tile_list=None, **kwargs):
@@ -391,7 +392,7 @@ class AwsProduct(AwsService):
 
         :param filename: name of file
         :type filename: str
-        :param data_format: format of file, if None it will be set automatically
+        :param data_format: format of file, if `None` it will be set automatically
         :type data_format: constants.MimeType or None
         :return: url of file location
         :rtype: str
@@ -406,7 +407,7 @@ class AwsProduct(AwsService):
         """
         Creates base url of product location on AWS.
 
-        :param force_http: True if HTTP base URL should be used and False otherwise
+        :param force_http: `True` if HTTP base URL should be used and `False` otherwise
         :type force_http: str
         :return: url of product location
         :rtype: str
@@ -416,9 +417,9 @@ class AwsProduct(AwsService):
 
     def get_tile_url(self, tile_info):
         """
-        Collects tile url from productInfo.json file.
+        Collects tile url from `productInfo.json` file.
 
-        :param tile_info: information about tile from productInfo.json
+        :param tile_info: information about tile from `productInfo.json`
         :type tile_info: dict
         :return: url of tile location
         :rtype: str
@@ -445,7 +446,7 @@ class AwsTile(AwsService):
     :param time: Tile sensing time in ISO8601 format
     :type time: str
     :param aws_index: There exist Sentinel-2 tiles with the same tile and time parameter. Therefore each tile on AWS
-                      also has an index which is visible in their url path. If ``aws_index`` is set to ``None`` the
+                      also has an index which is visible in their url path. If ``aws_index`` is set to `None` the
                       class will try to find the index automatically. If there will be multiple choices it will choose
                       the lowest index and inform the user.
     :type aws_index: int or None
@@ -454,11 +455,11 @@ class AwsTile(AwsService):
     :type data_source: constants.DataSource
     :param parent_folder: folder where the fetched data will be saved.
     :type parent_folder: str
-    :param bands: List of Sentinel-2 bands for request. If parameter is set to ``None`` all bands will be used.
+    :param bands: List of Sentinel-2 bands for request. If parameter is set to `None` all bands will be used.
     :type bands: list(str) or None
     :param metafiles: List of additional metafiles available on AWS
                       (e.g. ``['metadata', 'tileInfo', 'preview/B01', 'TCI']``).
-                      If parameter is set to ``None`` the list will be set automatically.
+                      If parameter is set to `None` the list will be set automatically.
     :type metafiles: list(str) or None
     """
     def __init__(self, tile_name, time, aws_index=None, data_source=DataSource.SENTINEL2_L1C, **kwargs):
@@ -604,7 +605,7 @@ class AwsTile(AwsService):
         """
         Creates base url of tile location on AWS.
 
-        :param force_http: True if HTTP base URL should be used and False otherwise
+        :param force_http: `True` if HTTP base URL should be used and `False` otherwise
         :type force_http: str
         :return: url of tile location
         :rtype: str
@@ -681,7 +682,7 @@ class AwsTile(AwsService):
         """
         :param tile_id: original tile identification string provided by ESA (e.g.
                         'S2A_OPER_MSI_L1C_TL_SGS__20160109T230542_A002870_T10UEV_N02.01')
-        :type: str
+        :type tile_id: str
         :return: tile name, sensing date and AWS index
         :rtype: (str, str, int)
         """

--- a/sentinelhub/aws_safe.py
+++ b/sentinelhub/aws_safe.py
@@ -10,10 +10,11 @@ from .download import get_xml
 
 
 class SafeProduct(AwsProduct):
-    """ Class inherits from `aws.AwsProduct`"""
+    """ Class implementing transformation of satellite products from AWS into .SAFE structure
+    """
+
     def get_requests(self):
-        """
-        Creates product structure and returns list of files for download
+        """ Creates product structure and returns list of files for download
 
         :return: list of download requests
         :rtype: list(download.DownloadRequest)
@@ -26,8 +27,7 @@ class SafeProduct(AwsProduct):
         return self.download_list, self.folder_list
 
     def get_safe_struct(self):
-        """
-        Describes a structure inside tile folder of ESA product .SAFE structure
+        """ Describes a structure inside tile folder of ESA product .SAFE structure
 
         :return: nested dictionaries representing .SAFE structure
         :rtype: dict
@@ -89,7 +89,7 @@ class SafeProduct(AwsProduct):
 
     def get_datastrip_list(self):
         """
-        :return: list of datastrips folder names and urls from productInfo.json file
+        :return: list of datastrips folder names and urls from `productInfo.json` file
         :rtype: list((str, str))
         """
         datastrips = self.product_info['datastrips']
@@ -110,7 +110,7 @@ class SafeProduct(AwsProduct):
     def get_datastrip_metadata_name(self, datastrip_folder):
         """
         :param datastrip_folder: name of datastrip folder
-        :type: str
+        :type datastrip_folder: str
         :return: name of datastrip metadata file
         :rtype: str
         """
@@ -154,15 +154,17 @@ class SafeProduct(AwsProduct):
 
 
 class SafeTile(AwsTile):
-    """ Class inherits from `aws.AwsTile`"""
+    """ Class implementing transformation of satellite tiles from AWS into .SAFE structure
+    """
     def __init__(self, *args, **kwargs):
+        """ Initialization parameters are inherited from parent class
+        """
         super().__init__(*args, **kwargs)
 
         self.tile_id = self.get_tile_id()
 
     def get_requests(self):
-        """
-        Creates tile structure and returns list of files for download.
+        """ Creates tile structure and returns list of files for download.
 
         :return: list of download requests for
         :rtype: list(download.DownloadRequest)
@@ -175,8 +177,7 @@ class SafeTile(AwsTile):
         return self.download_list, self.folder_list
 
     def get_safe_struct(self):
-        """
-        Describes a structure inside tile folder of ESA product .SAFE structure.
+        """ Describes a structure inside tile folder of ESA product .SAFE structure.
 
         :return: nested dictionaries representing .SAFE structure
         :rtype: dict
@@ -248,7 +249,7 @@ class SafeTile(AwsTile):
         return safe
 
     def get_tile_id(self):
-        """Creates ESA tile ID
+        """ Creates ESA tile ID
 
         :return: ESA tile ID
         :rtype: str
@@ -348,7 +349,7 @@ class SafeTile(AwsTile):
         return '{}.{}'.format(name, data_format.value)
 
     def get_preview_name(self):
-        """Returns .SAFE name of full resolution L1C preview
+        """ Returns .SAFE name of full resolution L1C preview
         :return: name of preview file
         :rtype: str
         """
@@ -360,8 +361,7 @@ class SafeTile(AwsTile):
 
 
 def _edit_name(name, code, add_code=None, delete_end=False):
-    """
-    Helping function for creating file names in .SAFE format
+    """ Helping function for creating file names in .SAFE format
 
     :param name: initial string
     :type name: str

--- a/sentinelhub/config.py
+++ b/sentinelhub/config.py
@@ -1,5 +1,5 @@
 """
-Module that collects configuration data from config.json
+Module for managing configuration data from `config.json`
 """
 
 import os
@@ -39,8 +39,7 @@ class SHConfig:
 
     """
     class _SHConfig:
-        """
-        Private class.
+        """ Internal class holding configuration parameters
         """
         CONFIG_PARAMS = OrderedDict([
             ('instance_id', ''),
@@ -66,8 +65,7 @@ class SHConfig:
             self.load_configuration()
 
         def _check_configuration(self, config):
-            """
-            Checks if configuration file contains all keys.
+            """ Checks if configuration file contains all keys.
 
             :param config: configuration dictionary read from ``config.json``
             :type config: dict
@@ -86,7 +84,7 @@ class SHConfig:
 
         @staticmethod
         def get_config_file():
-            """Checks if configuration file exists and returns its file path
+            """ Checks if configuration file exists and returns its file path
 
             :return: location of configuration file
             :rtype: str
@@ -99,8 +97,7 @@ class SHConfig:
             return config_file
 
         def load_configuration(self):
-            """
-            Method reads and loads the configuration file.
+            """ Method reads and loads the configuration file.
             """
             with open(self.get_config_file(), 'r') as cfg_file:
                 config = json.load(cfg_file)
@@ -111,7 +108,7 @@ class SHConfig:
                         setattr(self, prop, config[prop])
 
         def get_config(self):
-            """Returns ordered dictionary with configuration parameters
+            """ Returns ordered dictionary with configuration parameters
 
             :return: Ordered dictionary
             :rtype: collections.OrderedDict
@@ -122,8 +119,7 @@ class SHConfig:
             return config
 
         def save_configuration(self):
-            """
-            Method saves changed parameter values to the configuration file.
+            """ Method saves changed parameter values to the configuration file.
             """
             config = self.get_config()
 
@@ -159,7 +155,7 @@ class SHConfig:
         """Method that saves configuration parameter changes from instance of SHConfig class to global config class and
         to `config.json` file.
 
-        Example of use case
+        :Example:
             ``my_config = SHConfig()`` \n
             ``my_config.instance_id = '<new instance id>'`` \n
             ``my_config.save()``
@@ -173,12 +169,11 @@ class SHConfig:
             self._instance.save_configuration()
 
     def reset(self, params=...):
-        """
-        Resets configuration class to initial values. Use SHConfig.save() method in order to save this change.
+        """ Resets configuration class to initial values. Use `SHConfig.save()` method in order to save this change.
 
         :param params: Parameters which will be reset. Parameters can be specified with a list of names, e.g.
-        ``['instance_id', 'aws_access_key_id', 'aws_secret_access_key']``, or as a single name, e.g.
-        ``'ogc_base_url'``. By default all parameters will be reset and default value is ``Ellipsis``.
+            ``['instance_id', 'aws_access_key_id', 'aws_secret_access_key']``, or as a single name, e.g.
+            ``'ogc_base_url'``. By default all parameters will be reset and default value is ``Ellipsis``.
         :type params: Ellipsis or list(str) or str
         """
         if params is ...:
@@ -229,7 +224,7 @@ class SHConfig:
     def is_eocloud_ogc_url(self):
         """ Checks if base OGC URL is set to eocloud URL
 
-        :return: ``True`` if 'eocloud' string is in base OGC URL else ``False``
+        :return: `True` if 'eocloud' string is in base OGC URL else `False`
         :rtype: bool
         """
         return 'eocloud' in self.ogc_base_url

--- a/sentinelhub/config.py
+++ b/sentinelhub/config.py
@@ -152,7 +152,7 @@ class SHConfig:
         return json.dumps(self.get_config_dict(), indent=2)
 
     def save(self):
-        """Method that saves configuration parameter changes from instance of SHConfig class to global config class and
+        """ Method that saves configuration parameter changes from instance of SHConfig class to global config class and
         to `config.json` file.
 
         :Example:
@@ -198,7 +198,7 @@ class SHConfig:
         setattr(self, param, self._instance.CONFIG_PARAMS[param])
 
     def get_params(self):
-        """Returns a list of parameter names
+        """ Returns a list of parameter names
 
         :return: List of parameter names
         :rtype: list(str)

--- a/sentinelhub/constants.py
+++ b/sentinelhub/constants.py
@@ -1,5 +1,5 @@
 """
-Module with enum constants and utm utils
+Module defining constants and enumerate types used in the package
 """
 
 import functools
@@ -142,7 +142,7 @@ class DataSource(Enum):
         """ Maps data source to string identifier for WFS
 
         :param data_source: One of the supported data sources
-        :type: DataSource
+        :type data_source: DataSource
         :return: Product identifier for WFS
         :rtype: str
         """
@@ -173,7 +173,7 @@ class DataSource(Enum):
 
         :param self: One of the supported data sources
         :type self: DataSource
-        :return: ``True`` if source is Sentinel-1 and ``False`` otherwise
+        :return: `True` if source is Sentinel-1 and `False` otherwise
         :rtype: bool
         """
         return self.value[0] is _Source.SENTINEL1
@@ -185,7 +185,7 @@ class DataSource(Enum):
 
         :param self: One of the supported data sources
         :type self: DataSource
-        :return: ``True`` if data source is time independent and ``False`` otherwise
+        :return: `True` if data source is time independent and `False` otherwise
         :rtype: bool
         """
         return self.value[0] is _Source.DEM
@@ -197,7 +197,7 @@ class DataSource(Enum):
 
         :param self: One of the supported data sources
         :type self: DataSource
-        :return: ``True`` if data source exists at US West server and ``False`` otherwise
+        :return: `True` if data source exists at US West server and `False` otherwise
         :rtype: bool
         """
         return not SHConfig().is_eocloud_ogc_url() and self.value[0] in [_Source.LANDSAT8, _Source.MODIS, _Source.DEM]
@@ -218,7 +218,7 @@ class DataSource(Enum):
 
 
 class CRSMeta(EnumMeta):
-    """ Meta-class used for building CRS Enum class
+    """ Metaclass used for building CRS Enum class
     """
     def __new__(mcs, cls, bases, classdict):
         """ This is executed at the beginning of runtime when CRS class is created
@@ -266,7 +266,7 @@ class CRS(Enum, metaclass=CRSMeta):
 
         :param value: The string representation of the enum constant.
         :type value: str
-        :return: ``True`` if there exists a constant with string value `value`, ``False`` otherwise
+        :return: `True` if there exists a constant with string value `value`, `False` otherwise
         :rtype: bool
         """
         return any(value == item.value for item in cls)
@@ -295,7 +295,7 @@ class CRS(Enum, metaclass=CRSMeta):
 
         :param self: An enum constant representing a coordinate reference system.
         :type self: CRS
-        :return: True if crs is UTM and False otherwise
+        :return: `True` if crs is UTM and `False` otherwise
         :rtype: bool
         """
         return self.name.startswith('UTM')
@@ -455,7 +455,7 @@ class MimeType(Enum):
 
         :param self: File format
         :type self: MimeType
-        :return: ``True`` if file is in image format, ``False`` otherwise
+        :return: `True` if file is in image format, `False` otherwise
         :rtype: bool
         """
         return self in frozenset([MimeType.TIFF, MimeType.TIFF_d8, MimeType.TIFF_d16, MimeType.TIFF_d32f, MimeType.PNG,
@@ -468,7 +468,7 @@ class MimeType(Enum):
 
         :param self: File format
         :type self: MimeType
-        :return: ``True`` if file is in image format, ``False`` otherwise
+        :return: `True` if file is in image format, `False` otherwise
         :rtype: bool
         """
         return self in frozenset([MimeType.TIFF, MimeType.TIFF_d8, MimeType.TIFF_d16, MimeType.TIFF_d32f])
@@ -479,7 +479,7 @@ class MimeType(Enum):
 
         :param value: The string representation of the enum constant
         :type value: str
-        :return: ``True`` if there exists a constant with string value ``value``, ``False`` otherwise
+        :return: `True` if there exists a constant with string value ``value``, `False` otherwise
         :rtype: bool
         """
         return any(value == item.value for item in cls)

--- a/sentinelhub/data_request.py
+++ b/sentinelhub/data_request.py
@@ -1,5 +1,5 @@
 """
-Main module for obtaining data.
+Main module for collecting data
 """
 
 import datetime
@@ -83,8 +83,7 @@ class DataRequest(ABC):
 
     def get_data(self, *, save_data=False, data_filter=None, redownload=False, max_threads=None,
                  raise_download_errors=True):
-        """
-        Get requested data either by downloading it or by reading it from the disk (if it
+        """ Get requested data either by downloading it or by reading it from the disk (if it
         was previously downloaded and saved).
 
         :param save_data: flag to turn on/off saving of data to disk. Default is `False`.
@@ -111,8 +110,7 @@ class DataRequest(ABC):
         return self._add_saved_data(data_list, data_filter, raise_download_errors)
 
     def save_data(self, *, data_filter=None, redownload=False, max_threads=None, raise_download_errors=False):
-        """
-        Saves data to disk. If ``redownload=True`` then the data is redownloaded using ``max_threads`` workers.
+        """ Saves data to disk. If ``redownload=True`` then the data is redownloaded using ``max_threads`` workers.
 
         :param data_filter: Used to specify which items will be returned by the method and in which order. E.g. with
             `data_filter=[0, 2, -1]` the method will return only 1st, 3rd and last item. Default filter is `None`.
@@ -130,7 +128,7 @@ class DataRequest(ABC):
         self._execute_data_download(data_filter, redownload, max_threads, raise_download_errors)
 
     def _execute_data_download(self, data_filter, redownload, max_threads, raise_download_errors):
-        """Calls download module and executes the download process
+        """ Calls download module and executes the download process
 
         :param data_filter: Used to specify which items will be returned by the method and in which order. E.g. with
             `data_filter=[0, 2, -1]` the method will return only 1st, 3rd and last item. Default filter is `None`.
@@ -199,8 +197,7 @@ class DataRequest(ABC):
         return unique_download_list, mapping_list
 
     def _preprocess_request(self, save_data, return_data):
-        """
-        Prepares requests for download and creates empty folders
+        """ Prepares requests for download and creates empty folders
 
         :param save_data: Tells whether to save data or not
         :type save_data: bool
@@ -224,8 +221,7 @@ class DataRequest(ABC):
                 make_folder(os.path.join(self.data_folder, folder))
 
     def _add_saved_data(self, data_list, data_filter, raise_download_errors):
-        """
-        Adds already saved data that was not redownloaded to the requested data list.
+        """ Adds already saved data that was not redownloaded to the requested data list.
         """
         filtered_download_list = self.download_list if data_filter is None else \
             [self.download_list[index] for index in data_filter]
@@ -315,7 +311,7 @@ class OgcRequest(DataRequest):
         super().__init__(**kwargs)
 
     def _check_custom_url_parameters(self):
-        """Checks if custom url parameters are valid parameters.
+        """ Checks if custom url parameters are valid parameters.
 
         Throws ValueError if the provided parameter is not a valid parameter.
         """
@@ -327,7 +323,7 @@ class OgcRequest(DataRequest):
             raise ValueError('{} should not be a custom url parameter of a FIS request'.format(CustomUrlParam.GEOMETRY))
 
     def create_request(self, reset_wfs_iterator=False):
-        """Set download requests
+        """ Set download requests
 
         Create a list of DownloadRequests for all Sentinel-2 acquisitions within request's time interval and
         acceptable cloud coverage.
@@ -345,7 +341,7 @@ class OgcRequest(DataRequest):
         self.wfs_iterator = ogc_service.get_wfs_iterator()
 
     def get_dates(self):
-        """Get list of dates
+        """ Get list of dates
 
         List of all available Sentinel-2 acquisitions for given bbox with max cloud coverage and the specified
         time interval. When a single time is specified the request will return that specific date, if it exists.
@@ -359,7 +355,7 @@ class OgcRequest(DataRequest):
         return OgcImageService(instance_id=self.instance_id).get_dates(self)
 
     def get_tiles(self):
-        """Returns iterator over info about all satellite tiles used for the OgcRequest
+        """ Returns iterator over info about all satellite tiles used for the OgcRequest
 
         :return: Iterator of dictionaries containing info about all satellite tiles used in the request. In case of
                  DataSource.DEM it returns None.
@@ -652,7 +648,7 @@ class GeopediaWmsRequest(GeopediaRequest):
         super().__init__(layer=layer, theme=theme, bbox=bbox, service_type=ServiceType.WMS, **kwargs)
 
     def _check_custom_url_parameters(self):
-        """Checks if custom url parameters are valid parameters.
+        """ Checks if custom url parameters are valid parameters.
 
         Throws ValueError if the provided parameter is not a valid parameter.
         """
@@ -661,7 +657,7 @@ class GeopediaWmsRequest(GeopediaRequest):
                 raise ValueError('Parameter {} is currently not supported.'.format(param))
 
     def create_request(self):
-        """Set download requests
+        """ Set download requests
 
         Create a list of DownloadRequests for all Sentinel-2 acquisitions within request's time interval and
         acceptable cloud coverage.
@@ -671,7 +667,7 @@ class GeopediaWmsRequest(GeopediaRequest):
 
 
 class GeopediaImageRequest(GeopediaRequest):
-    """Request to access data in a Geopedia vector / raster layer.
+    """ Request to access data in a Geopedia vector / raster layer.
 
     :param image_field_name: Name of the field in the data table which holds images
     :type image_field_name: str
@@ -703,7 +699,7 @@ class GeopediaImageRequest(GeopediaRequest):
         super().__init__(service_type=ServiceType.IMAGE, **kwargs)
 
     def create_request(self, reset_gpd_iterator=False):
-        """Set a list of download requests
+        """ Set a list of download requests
 
         Set a list of DownloadRequests for all images that are under the
         given property of the Geopedia's Vector layer.
@@ -721,7 +717,7 @@ class GeopediaImageRequest(GeopediaRequest):
         self.gpd_iterator = gpd_service.get_gpd_iterator()
 
     def get_items(self):
-        """Returns iterator over info about data used for this request
+        """ Returns iterator over info about data used for this request
 
         :return: Iterator of dictionaries containing info about data used in
                  this request.
@@ -858,8 +854,8 @@ class AwsTileRequest(AwsRequest):
 
 
 def get_safe_format(product_id=None, tile=None, entire_product=False, bands=None, data_source=DataSource.SENTINEL2_L1C):
-    """
-    Returns .SAFE format structure in form of nested dictionaries. Either ``product_id`` or ``tile`` must be specified.
+    """ Returns .SAFE format structure in form of nested dictionaries. Either ``product_id`` or ``tile`` must be
+    specified.
 
     :param product_id: original ESA product identification string. Default is `None`
     :type product_id: str
@@ -891,8 +887,7 @@ def get_safe_format(product_id=None, tile=None, entire_product=False, bands=None
 
 def download_safe_format(product_id=None, tile=None, folder='.', redownload=False, entire_product=False, bands=None,
                          data_source=DataSource.SENTINEL2_L1C):
-    """
-    Downloads .SAFE format structure in form of nested dictionaries. Either ``product_id`` or ``tile`` must
+    """ Downloads .SAFE format structure in form of nested dictionaries. Either ``product_id`` or ``tile`` must
     be specified.
 
     :param product_id: original ESA product identification string. Default is `None`

--- a/sentinelhub/data_request.py
+++ b/sentinelhub/data_request.py
@@ -87,20 +87,20 @@ class DataRequest(ABC):
         Get requested data either by downloading it or by reading it from the disk (if it
         was previously downloaded and saved).
 
-        :param save_data: flag to turn on/off saving of data to disk. Default is ``False``.
+        :param save_data: flag to turn on/off saving of data to disk. Default is `False`.
         :type save_data: bool
-        :param redownload: if ``True``, download again the requested data even though it's already saved to disk.
-                            Default is ``False``, do not download if data is already available on disk.
+        :param redownload: if `True`, download again the requested data even though it's already saved to disk.
+                            Default is `False`, do not download if data is already available on disk.
         :type redownload: bool
         :param data_filter: Used to specify which items will be returned by the method and in which order. E.g. with
-            ``data_filter=[0, 2, -1]`` the method will return only 1st, 3rd and last item. Default filter is ``None``.
+            ``data_filter=[0, 2, -1]`` the method will return only 1st, 3rd and last item. Default filter is `None`.
         :type data_filter: list(int) or None
         :param max_threads: number of threads to use when downloading data; default is ``max_threads=None`` which
             by default uses the number of processors on the system
         :type max_threads: int
-        :param raise_download_errors: If ``True`` any error in download process should be raised as
-            ``DownloadFailedException``. If ``False`` failed downloads will only raise warnings and the method will
-            return list with ``None`` values in places where the results of failed download requests should be.
+        :param raise_download_errors: If `True` any error in download process should be raised as
+            ``DownloadFailedException``. If `False` failed downloads will only raise warnings and the method will
+            return list with `None` values in places where the results of failed download requests should be.
         :type raise_download_errors: bool
         :return: requested images as numpy arrays, where each array corresponds to a single acquisition and has
                     shape ``[height, width, channels]``.
@@ -115,15 +115,15 @@ class DataRequest(ABC):
         Saves data to disk. If ``redownload=True`` then the data is redownloaded using ``max_threads`` workers.
 
         :param data_filter: Used to specify which items will be returned by the method and in which order. E.g. with
-            `data_filter=[0, 2, -1]` the method will return only 1st, 3rd and last item. Default filter is ``None``.
+            `data_filter=[0, 2, -1]` the method will return only 1st, 3rd and last item. Default filter is `None`.
         :type data_filter: list(int) or None
-        :param redownload: data is redownloaded if ``redownload=True``. Default is ``False``
+        :param redownload: data is redownloaded if ``redownload=True``. Default is `False`
         :type redownload: bool
         :param max_threads: number of threads to use when downloading data; default is ``max_threads=None`` which
             by default uses the number of processors on the system
         :type max_threads: int
-        :param raise_download_errors: If ``True`` any error in download process should be raised as
-            ``DownloadFailedException``. If ``False`` failed downloads will only raise warnings.
+        :param raise_download_errors: If `True` any error in download process should be raised as
+            ``DownloadFailedException``. If `False` failed downloads will only raise warnings.
         :type raise_download_errors: bool
         """
         self._preprocess_request(True, False)
@@ -133,14 +133,14 @@ class DataRequest(ABC):
         """Calls download module and executes the download process
 
         :param data_filter: Used to specify which items will be returned by the method and in which order. E.g. with
-            `data_filter=[0, 2, -1]` the method will return only 1st, 3rd and last item. Default filter is ``None``.
+            `data_filter=[0, 2, -1]` the method will return only 1st, 3rd and last item. Default filter is `None`.
         :type data_filter: list(int) or None
-        :param redownload: data is redownloaded if ``redownload=True``. Default is ``False``
+        :param redownload: data is redownloaded if ``redownload=True``. Default is `False`
         :type redownload: bool
         :param max_threads: the number of workers to use when downloading, default ``max_threads=None``
         :type max_threads: int
-        :param raise_download_errors: If ``True`` any error in download process should be raised as
-            ``DownloadFailedException``. If ``False`` failed downloads will only raise warnings.
+        :param raise_download_errors: If `True` any error in download process should be raised as
+            ``DownloadFailedException``. If `False` failed downloads will only raise warnings.
         :type raise_download_errors: bool
         :return: List of data obtained from download
         :rtype: list
@@ -203,9 +203,9 @@ class DataRequest(ABC):
         Prepares requests for download and creates empty folders
 
         :param save_data: Tells whether to save data or not
-        :type: bool
+        :type save_data: bool
         :param return_data: Tells whether to return data or not
-        :type: bool
+        :type return_data: bool
         """
         if not self.is_valid_request():
             raise ValueError('Cannot obtain data because request is invalid')
@@ -273,7 +273,7 @@ class OgcRequest(DataRequest):
                         in some cases 32-bit TIFF is required, i.e. if requesting unprocessed raw bands.
                         Default is ``constants.MimeType.PNG``.
     :type image_format: constants.MimeType
-    :param instance_id: user's instance id. If ``None`` the instance id is taken from the ``config.json``
+    :param instance_id: user's instance id. If `None` the instance id is taken from the ``config.json``
                         configuration file.
     :type instance_id: str
     :param custom_url_params: dictionary of CustomUrlParameters and their values supported by Sentinel Hub's WMS and WCS
@@ -408,7 +408,7 @@ class WmsRequest(OgcRequest):
                         in some cases 32-bit TIFF is required, i.e. if requesting unprocessed raw bands.
                         Default is ``constants.MimeType.PNG``.
     :type image_format: constants.MimeType
-    :param instance_id: User's Sentinel Hub instance id. If ``None`` the instance id is taken from the ``config.json``
+    :param instance_id: User's Sentinel Hub instance id. If `None` the instance id is taken from the ``config.json``
                         configuration file.
     :type instance_id: str
     :param custom_url_params: dictionary of CustomUrlParameters and their values supported by Sentinel Hub's WMS and WCS
@@ -475,7 +475,7 @@ class WcsRequest(OgcRequest):
                         in some cases 32-bit TIFF is required, i.e. if requesting unprocessed raw bands.
                         Default is ``constants.MimeType.PNG``.
     :type image_format: constants.MimeType
-    :param instance_id: user's instance id. If ``None`` the instance id is taken from the ``config.json``
+    :param instance_id: user's instance id. If `None` the instance id is taken from the ``config.json``
                         configuration file.
     :type instance_id: str
     :param custom_url_params: dictionary of CustomUrlParameters and their values supported by Sentinel Hub's WMS and WCS
@@ -483,7 +483,7 @@ class WcsRequest(OgcRequest):
                               http://www.sentinel-hub.com/develop/documentation/api/custom-url-parameters. Note: in
                               case of constants.CustomUrlParam.EVALSCRIPT the dictionary value must be a string
                               of Javascript code that is not encoded into base64.
-    :type custom_url_params: dictionary of CustomUrlParameter enum and its value, i.e.
+    :type custom_url_params: Dictionary of CustomUrlParameter enum and its value, i.e.
                               ``{constants.CustomUrlParam.ATMFILTER:'ATMCOR'}``
     :param time_difference: The time difference below which dates are deemed equal. That is, if for the given set of OGC
                             parameters the images are available at datestimes `d1<=d2<=...<=dn` then only those with
@@ -516,22 +516,20 @@ class FisRequest(OgcRequest):
         match the one given by `data_source` parameter
     :type layer: str
     :param time: time or time range for which to return the results, in ISO8601 format
-            (year-month-date, for example: ``2016-01-01``, or year-month-dateThours:minuts:seconds format,
-            i.e. ``2016-01-01T16:31:21``).
-            Examples: ``'2016-01-01'``, or ``('2016-01-01', ' 2016-01-31')``
+        (year-month-date, for example: ``2016-01-01``, or year-month-dateThours:minuts:seconds format,
+        i.e. ``2016-01-01T16:31:21``). Examples: ``'2016-01-01'``, or ``('2016-01-01', ' 2016-01-31')``
     :type time: str or (str, str) or datetime.date or (datetime.date, datetime.date) or datetime.datetime or
-                (datetime.datetime, datetime.datetime)
+        (datetime.datetime, datetime.datetime)
     :param geometry_list: A WKT representation of a geometry describing the region of interest.
-                     Note that WCS 1.1.1 standard is used here, so for EPSG:4326 coordinates should be
-                     in latitude/longitude order.
+        Note that WCS 1.1.1 standard is used here, so for EPSG:4326 coordinates should be in latitude/longitude order.
     :type geometry_list: list, [geometry.Geometry or geometry.Bbox]
     :param resolution: Specifies the spatial resolution, in meters per pixel, of the image from which the statistics
-                       are to be estimated. When using CRS=EPSG:4326 one has to add the "m" suffix to
-                       enforce resolution in meters per pixel (e.g. RESOLUTION=10m).
-    :type str
+        are to be estimated. When using CRS=EPSG:4326 one has to add the "m" suffix to
+        enforce resolution in meters per pixel (e.g. RESOLUTION=10m).
+    :type resolution: str
     :param bins: The number of bins (a positive integer) in the histogram. If this parameter is absent no histogram
         is computed.
-    :type: str
+    :type bins: str
     :param histogram_type: type of histogram
     :type histogram_type: HistogramType
     :param data_source: Source of requested satellite data. It has to be the same as defined in Sentinel Hub
@@ -539,16 +537,16 @@ class FisRequest(OgcRequest):
     :type data_source: constants.DataSource
     :param maxcc: maximum accepted cloud coverage of an image. Float between 0.0 and 1.0. Default is ``1.0``.
     :type maxcc: float
-    :param instance_id: user's instance id. If ``None`` the instance id is taken from the ``config.json``
-                        configuration file.
+    :param instance_id: user's instance id. If `None` the instance id is taken from the ``config.json``
+        configuration file.
     :type instance_id: str
-    :param custom_url_params: dictionary of CustomUrlParameters and their values supported by Sentinel Hub's WMS and WCS
-                              services. All available parameters are described at
-                              http://www.sentinel-hub.com/develop/documentation/api/custom-url-parameters. Note: in
-                              case of constants.CustomUrlParam.EVALSCRIPT the dictionary value must be a string
-                              of Javascript code that is not encoded into base64.
+    :param custom_url_params: Dictionary of CustomUrlParameters and their values supported by Sentinel Hub's WMS and WCS
+        services. All available parameters are described at
+        http://www.sentinel-hub.com/develop/documentation/api/custom-url-parameters. Note: in
+        case of constants.CustomUrlParam.EVALSCRIPT the dictionary value must be a string
+        of Javascript code that is not encoded into base64.
     :type custom_url_params: dictionary of CustomUrlParameter enum and its value, i.e.
-                              ``{constants.CustomUrlParam.ATMFILTER:'ATMCOR'}``
+        ``{constants.CustomUrlParam.ATMFILTER:'ATMCOR'}``
     :param data_folder: location of the directory where the fetched data will be saved.
     :type data_folder: str
     """
@@ -561,7 +559,7 @@ class FisRequest(OgcRequest):
         super().__init__(bbox=None, layer=layer, time=time, service_type=ServiceType.FIS, **kwargs)
 
     def create_request(self):
-        """Set download requests
+        """ Set download requests
 
         Create a list of DownloadRequests for all Sentinel-2 acquisitions within request's time interval and
         acceptable cloud coverage.
@@ -677,9 +675,9 @@ class GeopediaImageRequest(GeopediaRequest):
 
     :param image_field_name: Name of the field in the data table which holds images
     :type image_field_name: str
-    :param keep_image_names: If ``True`` images will be saved with the same names as in Geopedia otherwise Geopedia
+    :param keep_image_names: If `True` images will be saved with the same names as in Geopedia otherwise Geopedia
         hashes will be used as names. If there are multiple images with the same names in the Geopedia layer this
-        parameter should be set to ``False`` to prevent images being overwritten.
+        parameter should be set to `False` to prevent images being overwritten.
     :type keep_image_names: bool
     :param layer: Geopedia layer which contains requested data
     :type layer: str
@@ -745,8 +743,8 @@ class AwsRequest(DataRequest):
     :param metafiles: list of additional metafiles available on AWS
                       (e.g. ``['metadata', 'tileInfo', 'preview/B01', 'TCI']``)
     :type metafiles: list(str)
-    :param safe_format: flag that determines the structure of saved data. If ``True`` it will be saved in .SAFE format
-                        defined by ESA. If ``False`` it will be saved in the same structure as the stucture at AWS.
+    :param safe_format: flag that determines the structure of saved data. If `True` it will be saved in .SAFE format
+                        defined by ESA. If `False` it will be saved in the same structure as the stucture at AWS.
     :type safe_format: bool
     :param data_folder: location of the directory where the fetched data will be saved.
     :type data_folder: str
@@ -780,7 +778,7 @@ class AwsProductRequest(AwsRequest):
     :param product_id: original ESA product identification string
                        (e.g. ``'S2A_MSIL1C_20170414T003551_N0204_R016_T54HVH_20170414T003551'``)
     :type product_id: str
-    :param tile_list: list of tiles inside the product to be downloaded. If parameter is set to ``None`` all
+    :param tile_list: list of tiles inside the product to be downloaded. If parameter is set to `None` all
                       tiles inside the product will be downloaded.
     :type tile_list: list(str) or None
     :param bands: List of Sentinel-2 bands for request. If `None` all bands will be obtained
@@ -788,8 +786,8 @@ class AwsProductRequest(AwsRequest):
     :param metafiles: list of additional metafiles available on AWS
                       (e.g. ``['metadata', 'tileInfo', 'preview/B01', 'TCI']``)
     :type metafiles: list(str)
-    :param safe_format: flag that determines the structure of saved data. If ``True`` it will be saved in .SAFE format
-                        defined by ESA. If ``False`` it will be saved in the same structure as the stucture at AWS.
+    :param safe_format: flag that determines the structure of saved data. If `True` it will be saved in .SAFE format
+                        defined by ESA. If `False` it will be saved in the same structure as the stucture at AWS.
     :type safe_format: bool
     :param data_folder: location of the directory where the fetched data will be saved.
     :type data_folder: str
@@ -822,7 +820,7 @@ class AwsTileRequest(AwsRequest):
     :param time: tile sensing time in ISO8601 format
     :type time: str
     :param aws_index: there exist Sentinel-2 tiles with the same tile and time parameter. Therefore each tile on AWS
-                      also has an index which is visible in their url path. If aws_index is set to ``None`` the class
+                      also has an index which is visible in their url path. If aws_index is set to `None` the class
                       will try to find the index automatically. If there will be multiple choices it will choose the
                       lowest index and inform the user.
     :type aws_index: int or None
@@ -834,8 +832,8 @@ class AwsTileRequest(AwsRequest):
     :param metafiles: list of additional metafiles available on AWS
                       (e.g. ``['metadata', 'tileInfo', 'preview/B01', 'TCI']``)
     :type metafiles: list(str)
-    :param safe_format: flag that determines the structure of saved data. If ``True`` it will be saved in .SAFE format
-                        defined by ESA. If ``False`` it will be saved in the same structure as the stucture at AWS.
+    :param safe_format: flag that determines the structure of saved data. If `True` it will be saved in .SAFE format
+                        defined by ESA. If `False` it will be saved in the same structure as the stucture at AWS.
     :type safe_format: bool
     :param data_folder: location of the directory where the fetched data will be saved.
     :type data_folder: str
@@ -863,14 +861,14 @@ def get_safe_format(product_id=None, tile=None, entire_product=False, bands=None
     """
     Returns .SAFE format structure in form of nested dictionaries. Either ``product_id`` or ``tile`` must be specified.
 
-    :param product_id: original ESA product identification string. Default is ``None``
+    :param product_id: original ESA product identification string. Default is `None`
     :type product_id: str
-    :param tile: tuple containing tile name and sensing time/date. Default is ``None``
+    :param tile: tuple containing tile name and sensing time/date. Default is `None`
     :type tile: (str, str)
     :param entire_product: in case tile is specified this flag determines if it will be place inside a .SAFE structure
-                           of the product. Default is ``False``
+                           of the product. Default is `False`
     :type entire_product: bool
-    :param bands: list of bands to download. If ``None`` all bands will be downloaded. Default is ``None``
+    :param bands: list of bands to download. If `None` all bands will be downloaded. Default is `None`
     :type bands: list(str) or None
     :param data_source: In case of tile request the source of satellite data has to be specified. Default is Sentinel-2
                         L1C data.
@@ -897,19 +895,19 @@ def download_safe_format(product_id=None, tile=None, folder='.', redownload=Fals
     Downloads .SAFE format structure in form of nested dictionaries. Either ``product_id`` or ``tile`` must
     be specified.
 
-    :param product_id: original ESA product identification string. Default is ``None``
+    :param product_id: original ESA product identification string. Default is `None`
     :type product_id: str
-    :param tile: tuple containing tile name and sensing time/date. Default is ``None``
+    :param tile: tuple containing tile name and sensing time/date. Default is `None`
     :type tile: (str, str)
     :param folder: location of the directory where the fetched data will be saved. Default is ``'.'``
     :type folder: str
-    :param redownload: if ``True``, download again the requested data even though it's already saved to disk. If
-                       ``False``, do not download if data is already available on disk. Default is ``False``
+    :param redownload: if `True`, download again the requested data even though it's already saved to disk. If
+                       `False`, do not download if data is already available on disk. Default is `False`
     :type redownload: bool
     :param entire_product: in case tile is specified this flag determines if it will be place inside a .SAFE structure
-                           of the product. Default is ``False``
+                           of the product. Default is `False`
     :type entire_product: bool
-    :param bands: list of bands to download. If ``None`` all bands will be downloaded. Default is ``None``
+    :param bands: list of bands to download. If `None` all bands will be downloaded. Default is `None`
     :type bands: list(str) or None
     :param data_source: In case of tile request the source of satellite data has to be specified. Default is Sentinel-2
                         L1C data.

--- a/sentinelhub/download.py
+++ b/sentinelhub/download.py
@@ -53,21 +53,21 @@ class DownloadRequest:
     saved data and other necessary flags needed when the data is downloaded and
     interpreted.
 
-    :param url: url to Sentinel Hub's services or other sources from where the data is downloaded. Default is ``None``
+    :param url: url to Sentinel Hub's services or other sources from where the data is downloaded. Default is `None`
     :type url: str
-    :param data_folder: folder name where the fetched data will be (or already is) saved. Default is ``None``
+    :param data_folder: folder name where the fetched data will be (or already is) saved. Default is `None`
     :type data_folder: str
-    :param filename: filename of the file where the fetched data will be (or already is) saved. Default is ``None``
+    :param filename: filename of the file where the fetched data will be (or already is) saved. Default is `None`
     :type filename: str
-    :param headers: add HTTP headers to request. Default is ``None``
+    :param headers: add HTTP headers to request. Default is `None`
     :type headers: dict
     :param request_type: type of request, either GET or POST. Default is ``constants.RequestType.GET``
     :type request_type: constants.RequestType
-    :param post_values: form encoded data to send in POST request. Default is ``None``
+    :param post_values: form encoded data to send in POST request. Default is `None`
     :type post_values: dict
-    :param save_response: flag to turn on/off saving data downloaded by this request to disk. Default is ``True``.
+    :param save_response: flag to turn on/off saving data downloaded by this request to disk. Default is `True`.
     :type save_response: bool
-    :param return_data: flag to return or not data downloaded by this request to disk. Default is ``True``.
+    :param return_data: flag to return or not data downloaded by this request to disk. Default is `True`.
     :type return_data: bool
     :param data_type: expected file format of downloaded data. Default is ``constants.MimeType.RAW``
     :type data_type: constants.MimeType
@@ -142,7 +142,7 @@ class DownloadRequest:
         """
         Set save_response attribute
 
-        :param save_response: flag to turn on/off saving data downloaded by this request to disk. Default is ``True``.
+        :param save_response: flag to turn on/off saving data downloaded by this request to disk. Default is `True`.
         :return: bool
         """
         self.save_response = save_response
@@ -151,7 +151,7 @@ class DownloadRequest:
         """
         Set return_data attribute
 
-        :param return_data: flag to return or not data downloaded by this request to disk. Default is ``True``.
+        :param return_data: flag to return or not data downloaded by this request to disk. Default is `True`.
         :return: bool
         """
         self.return_data = return_data
@@ -159,7 +159,7 @@ class DownloadRequest:
     def is_downloaded(self):
         """ Checks if data for this request has already been downloaded and is saved to disk.
 
-        :return: returns ``True`` if data for this request has already been downloaded and is saved to disk.
+        :return: returns `True` if data for this request has already been downloaded and is saved to disk.
         :rtype: bool
         """
         if self.file_path is None:
@@ -169,7 +169,7 @@ class DownloadRequest:
     def is_aws_s3(self):
         """Checks if data has to be downloaded from AWS s3 bucket
 
-        :return: True if url describes location at AWS s3 bucket and False otherwise
+        :return: `True` if url describes location at AWS s3 bucket and `False` otherwise
         :rtype: bool
         """
         return self.url.startswith('s3://')
@@ -181,8 +181,8 @@ def download_data(request_list, redownload=False, max_threads=None):
 
     :param request_list: list of DownloadRequests
     :type request_list: list of DownloadRequests
-    :param redownload: if ``True``, download again the data, although it was already downloaded and is available
-                        on the disk. Default is ``False``.
+    :param redownload: if `True`, download again the data, although it was already downloaded and is available
+                        on the disk. Default is `False`.
     :type redownload: bool
     :param max_threads: number of threads to use when downloading data; default is ``max_threads=None`` which
             by default uses the number of processors on the system
@@ -206,9 +206,9 @@ def _check_if_must_download(request_list, redownload):
     **Note:** the function mutates the elements of the list!
 
     :param request_list: a list of ``DownloadRequest`` instances
-    :type: list[DownloadRequest]
+    :type request_list: list[DownloadRequest]
     :param redownload: tells whether to download the data again or not
-    :type: bool
+    :type redownload: bool
     """
     for request in request_list:
         request.will_download = (request.save_response or request.return_data) \
@@ -327,7 +327,7 @@ def _is_temporal_problem(exception):
 
     :param exception: Exception raised during download
     :type exception: Exception
-    :return: True if exception is temporal and False otherwise
+    :return: `True` if exception is temporal and `False` otherwise
     :rtype: bool
     """
     try:
@@ -342,7 +342,7 @@ def _request_limit_reached(exception):
 
     :param exception: Exception raised during download
     :type exception: Exception
-    :return: True if exception is caused because too many requests were executed at once and False otherwise
+    :return: `True` if exception is caused because too many requests were executed at once and `False` otherwise
     :rtype: bool
     """
     return isinstance(exception, requests.HTTPError) and \
@@ -465,9 +465,9 @@ def get_json(url, post_values=None, headers=None):
 
     :param url: url to Sentinel Hub's services or other sources from where the data is downloaded
     :type url: str
-    :param post_values: form encoded data to send in POST request. Default is ``None``
+    :param post_values: form encoded data to send in POST request. Default is `None`
     :type post_values: dict
-    :param headers: add HTTP headers to request. Default is ``None``
+    :param headers: add HTTP headers to request. Default is `None`
     :type headers: dict
     :return: request response as JSON instance
     :rtype: JSON instance or None

--- a/sentinelhub/download.py
+++ b/sentinelhub/download.py
@@ -34,14 +34,12 @@ class DownloadFailedException(Exception):
 
 
 class AwsDownloadFailedException(DownloadFailedException):
-    """
-    This exception is raised when download fails because of a missing file in AWS
+    """ This exception is raised when download fails because of a missing file in AWS
     """
 
 
 class ImageDecodingError(Exception):
-    """
-    This exception is raised when downloaded image is not properly decoded
+    """ This exception is raised when downloaded image is not properly decoded
     """
 
 
@@ -97,8 +95,7 @@ class DownloadRequest:
         self._set_file_path()
 
     def set_filename(self, filename):
-        """
-        Set filename attribute
+        """ Set filename attribute
 
         :param filename: Name of the file where .
         :return: str
@@ -107,8 +104,7 @@ class DownloadRequest:
         self._set_file_path()
 
     def set_data_folder(self, data_folder):
-        """
-        Set data_folder attribute
+        """ Set data_folder attribute
 
         :param data_folder: folder name where the fetched data will be (or already is) saved.
         :return: str
@@ -139,8 +135,7 @@ class DownloadRequest:
         return self.file_path
 
     def set_save_response(self, save_response):
-        """
-        Set save_response attribute
+        """ Set save_response attribute
 
         :param save_response: flag to turn on/off saving data downloaded by this request to disk. Default is `True`.
         :return: bool
@@ -148,8 +143,7 @@ class DownloadRequest:
         self.save_response = save_response
 
     def set_return_data(self, return_data):
-        """
-        Set return_data attribute
+        """ Set return_data attribute
 
         :param return_data: flag to return or not data downloaded by this request to disk. Default is `True`.
         :return: bool
@@ -167,7 +161,7 @@ class DownloadRequest:
         return os.path.exists(self.file_path)
 
     def is_aws_s3(self):
-        """Checks if data has to be downloaded from AWS s3 bucket
+        """ Checks if data has to be downloaded from AWS s3 bucket
 
         :return: `True` if url describes location at AWS s3 bucket and `False` otherwise
         :rtype: bool
@@ -200,8 +194,7 @@ def download_data(request_list, redownload=False, max_threads=None):
 
 
 def _check_if_must_download(request_list, redownload):
-    """
-    Updates request.will_download attribute of each request in request_list.
+    """ Updates request.will_download attribute of each request in request_list.
 
     **Note:** the function mutates the elements of the list!
 
@@ -382,6 +375,7 @@ def _create_download_failed_message(exception, url):
 
 def _save_if_needed(request, response_content):
     """ Save data to disk, if requested by the user
+
     :param request: Download request
     :type request: DownloadRequest
     :param response_content: content of the download response
@@ -432,7 +426,7 @@ def decode_data(response_content, data_type, entire_response=None):
 
 def decode_image(data, image_type):
     """ Decodes the image provided in various formats, i.e. png, 16-bit float tiff, 32-bit float tiff, jp2
-        and returns it as an numpy array
+    and returns it as an numpy array
 
     :param data: image in its original format
     :type data: any of possible image types

--- a/sentinelhub/fis.py
+++ b/sentinelhub/fis.py
@@ -1,5 +1,5 @@
 """
-Module for working with Sentinel Hub OGC services
+Module for working with Sentinel Hub FIS service
 """
 
 import logging
@@ -18,7 +18,6 @@ class FisService(OgcImageService):
 
     Intermediate layer between FIS requests and the Sentinel Hub FIS services.
     """
-
     def get_request(self, request):
         """ Get download requests
 
@@ -42,7 +41,7 @@ class FisService(OgcImageService):
         of request. The name of the file has the following structure:
 
         {service_type}_{layer}_{geometry}_{crs}_{start_time}_{end_time}_{resolution}_{bins}_{histogram_type}_
-        \*{custom_url_params}.json
+        \\*{custom_url_params}.json
 
         :param request: FIS request
         :type request: FisRequest

--- a/sentinelhub/fis.py
+++ b/sentinelhub/fis.py
@@ -14,7 +14,7 @@ LOGGER = logging.getLogger(__name__)
 
 
 class FisService(OgcImageService):
-    """Sentinel Hub OGC services class for providing FIS data
+    """ Sentinel Hub OGC services class for providing FIS data
 
     Intermediate layer between FIS requests and the Sentinel Hub FIS services.
     """
@@ -25,13 +25,11 @@ class FisService(OgcImageService):
         Create a list of DownloadRequests for all Sentinel-2 acquisitions within request's time interval and
         acceptable cloud coverage.
 
-
         :param request: OGC-type request with specified bounding box, time interval, and cloud coverage for specific
-                        product.
+            product.
         :type request: OgcRequest or GeopediaRequest
         :return: list of DownloadRequests
         """
-
         return [DownloadRequest(url=self.get_url(request=request, geometry=geometry),
                                 filename=self.get_filename(request, geometry),
                                 data_type=MimeType.JSON, headers=OgcConstants.HEADERS)
@@ -39,19 +37,17 @@ class FisService(OgcImageService):
 
     @staticmethod
     def get_filename(request, geometry):
-        """ Returns filename
-
-        Returns the filename's location on disk where data is or is going to be stored.
+        """ Returns the filename location on disk where data is or is going to be stored.
         The files are stored in the folder specified by the user when initialising OGC-type
         of request. The name of the file has the following structure:
 
         {service_type}_{layer}_{geometry}_{crs}_{start_time}_{end_time}_{resolution}_{bins}_{histogram_type}_
-        *{custom_url_params}.json
+        \*{custom_url_params}.json
 
         :param request: FIS request
         :type request: FisRequest
         :param geometry: geometry object
-        :type: BBox or Geometry
+        :type geometry: BBox or Geometry
         :return: filename for this request
         :rtype: str
         """

--- a/sentinelhub/geo_utils.py
+++ b/sentinelhub/geo_utils.py
@@ -1,5 +1,5 @@
 """
-Module for manipulation of geographical information.
+Module for manipulation of geographical information
 """
 
 import logging
@@ -19,7 +19,7 @@ def bbox_to_dimensions(bbox, resolution):
     :param bbox: bounding box
     :type bbox: geometry.BBox
     :param resolution: Resolution of desired image in meters. It can be a single number or a tuple of two numbers -
-    resolution in horizontal and resolution in vertical direction.
+        resolution in horizontal and resolution in vertical direction.
     :type resolution: float or (float, float)
     :return: width and height in pixels for given bounding box and pixel resolution
     :rtype: int, int
@@ -58,9 +58,9 @@ def get_image_dimension(bbox, width=None, height=None):
 
     :param bbox: bounding box
     :type bbox: geometry.BBox
-    :param width: image width or None if height is unknown
+    :param width: image width or `None` if height is unknown
     :type width: int or None
-    :param height: image height or None if height is unknown
+    :param height: image height or `None` if height is unknown
     :type height: int or None
     :return: width or height rounded to integer
     :rtype: int
@@ -144,7 +144,7 @@ def utm_to_pixel(east, north, transform, truncate=True):
     :type north: float
     :param transform: georeferencing transform of the image, e.g. `(x_upper_left, res_x, 0, y_upper_left, 0, -res_y)`
     :type transform: tuple or list
-    :param truncate: Whether to truncate pixel coordinates. Default is ``True``
+    :param truncate: Whether to truncate pixel coordinates. Default is `True`
     :type truncate: bool
     :return: row and column pixel image coordinates
     :rtype: float, float or int, int
@@ -185,7 +185,7 @@ def wgs84_to_pixel(lng, lat, transform, utm_epsg=None, truncate=True):
     :type transform: tuple or list
     :param utm_epsg: UTM coordinate reference system enum constants
     :type utm_epsg: constants.CRS or None
-    :param truncate: Whether to truncate pixel coordinates. Default is ``True``
+    :param truncate: Whether to truncate pixel coordinates. Default is `True`
     :type truncate: bool
     :return: row and column pixel image coordinates
     :rtype: float, float or int, int

--- a/sentinelhub/geometry.py
+++ b/sentinelhub/geometry.py
@@ -14,11 +14,12 @@ from .geo_utils import transform_point
 
 class BaseGeometry(ABC):
     """ Base geometry class
-
-    :param crs: Coordinate reference system of the geometry
-    :type crs: constants.CRS
     """
     def __init__(self, crs):
+        """
+        :param crs: Coordinate reference system of the geometry
+        :type crs: constants.CRS
+        """
         self._crs = CRS(crs)
 
     def __getattr__(self, item):
@@ -120,12 +121,13 @@ class BBox(BaseGeometry):
         - In case of ``constants.CRS.WGS84`` axis x represents longitude and axis y represents latitude
         - In case of ``constants.CRS.POP_WEB`` axis x represents easting and axis y represents northing
         - In case of ``constants.CRS.UTM_*`` axis x represents easting and axis y represents northing
-
-    :param bbox: A bbox in any valid representation
-    :param crs: Coordinate reference system of the bounding box
-    :type crs: constants.CRS
     """
     def __init__(self, bbox, crs):
+        """
+        :param bbox: A bbox in any valid representation
+        :param crs: Coordinate reference system of the bounding box
+        :type crs: constants.CRS
+        """
         x_fst, y_fst, x_snd, y_snd = BBox._to_tuple(bbox)
         self.min_x = min(x_fst, x_snd)
         self.max_x = max(x_fst, x_snd)
@@ -392,13 +394,14 @@ class Geometry(BaseGeometry):
     - `shapely.geometry.Polygon` or `shapely.geometry.MultiPolygon`
     - A GeoJSON dictionary with (multi)polygon coordinates
     - A WKT string with (multi)polygon coordinates
-
-    :param geometry: A polygon or multipolygon in any valid representation
-    :type geometry: shapely.geometry.Polygon or shapely.geometry.MultiPolygon or dict or str
-    :param crs: Coordinate reference system of the geometry
-    :type crs: constants.CRS
     """
     def __init__(self, geometry, crs):
+        """
+        :param geometry: A polygon or multipolygon in any valid representation
+        :type geometry: shapely.geometry.Polygon or shapely.geometry.MultiPolygon or dict or str
+        :param crs: Coordinate reference system of the geometry
+        :type crs: constants.CRS
+        """
         self._geometry = self._parse_geometry(geometry)
 
         super().__init__(crs)
@@ -485,11 +488,12 @@ class Geometry(BaseGeometry):
 
 class BBoxCollection(BaseGeometry):
     """ A collection of bounding boxes
-
-    :param bbox_list: A list of BBox objects which have to be in the same CRS
-    :type bbox_list: list(BBox)
     """
     def __init__(self, bbox_list):
+        """
+        :param bbox_list: A list of BBox objects which have to be in the same CRS
+        :type bbox_list: list(BBox)
+        """
         self._bbox_list, crs = self._parse_bbox_list(bbox_list)
         self._geometry = self._get_geometry()
 

--- a/sentinelhub/geopedia.py
+++ b/sentinelhub/geopedia.py
@@ -1,5 +1,5 @@
 """
-Module for working with Geopedia OGC services
+Module for working with Geopedia
 """
 
 import logging
@@ -18,12 +18,13 @@ LOGGER = logging.getLogger(__name__)
 
 class GeopediaService:
     """ The class for Geopedia OGC services
-
-    :param base_url: Base url of Geopedia REST services. If `None`, the url specified in the configuration
-                    file is taken.
-    :type base_url: str or None
     """
     def __init__(self, base_url=None):
+        """
+        :param base_url: Base url of Geopedia REST services. If `None`, the url specified in the configuration
+                    file is taken.
+        :type base_url: str or None
+        """
         self.base_url = SHConfig().geopedia_rest_url if base_url is None else base_url
 
     @staticmethod
@@ -54,19 +55,6 @@ class GeopediaSession(GeopediaService):
     starting and renewing of session and login (optional). It provides session headers required by Geopedia REST
     requests. Session duration is hardcoded to 1 hour with class attribute SESSION_DURATION. After that this
     class will automatically renew the session and login.
-
-    :param username: Optional parameter in case of login with Geopedia credentials
-    :type username: str or None
-    :param password: Optional parameter in case of login with Geopedia credentials
-    :type password: str or None
-    :param password_md5: Password can optionally also be provided as already encoded md5 hexadecimal string
-    :type password_md5: str or None
-    :param is_global: If `True` this session will be shared among all instances of this class, otherwise it will be
-        used only with the single instance. Default is `False`.
-    :type is_global: bool
-    :param base_url: Base url of Geopedia REST services. If `None`, the url specified in the configuration
-        file is taken.
-    :type base_url: str or None
     """
     SESSION_DURATION = datetime.timedelta(hours=1)
     UNAUTHENTICATED_USER_ID = 'NO_USER'
@@ -75,6 +63,20 @@ class GeopediaSession(GeopediaService):
     _global_session_start = None
 
     def __init__(self, *, username=None, password=None, password_md5=None, is_global=False, **kwargs):
+        """
+        :param username: Optional parameter in case of login with Geopedia credentials
+        :type username: str or None
+        :param password: Optional parameter in case of login with Geopedia credentials
+        :type password: str or None
+        :param password_md5: Password can optionally also be provided as already encoded md5 hexadecimal string
+        :type password_md5: str or None
+        :param is_global: If `True` this session will be shared among all instances of this class, otherwise it will be
+            used only with the single instance. Default is `False`.
+        :type is_global: bool
+        :param base_url: Base url of Geopedia REST services. If `None`, the url specified in the configuration
+            file is taken.
+        :type base_url: str or None
+        """
         super().__init__(**kwargs)
 
         if password and password_md5:
@@ -207,18 +209,19 @@ class GeopediaSession(GeopediaService):
 
 
 class GeopediaWmsService(GeopediaService, OgcImageService):
-    """Geopedia OGC services class for providing image data. Most of the methods are inherited from
+    """ Geopedia OGC services class for providing image data. Most of the methods are inherited from
     `sentinelhub.ogc.OgcImageService` class.
-
-    :param base_url: Base url of Geopedia WMS services. If `None`, the url specified in the configuration
-                    file is taken.
-    :type base_url: str or None
     """
     def __init__(self, base_url=None):
+        """
+        :param base_url: Base url of Geopedia WMS services. If `None`, the url specified in the configuration
+                    file is taken.
+        :type base_url: str or None
+        """
         super().__init__(base_url=SHConfig().geopedia_wms_url if base_url is None else base_url)
 
     def get_request(self, request):
-        """Get a list of DownloadRequests for all data that are under the given field in the table of a Geopedia layer.
+        """ Get a list of DownloadRequests for all data that are under the given field in the table of a Geopedia layer.
 
         :return: list of items which have to be downloaded
         :rtype: list(DownloadRequest)
@@ -244,19 +247,20 @@ class GeopediaWmsService(GeopediaService, OgcImageService):
 
 
 class GeopediaImageService(GeopediaService):
-    """Service class that provides images from a Geopedia vector layer.
-
-    :param base_url: Base url of Geopedia REST services. If `None`, the url
-                     specified in the configuration file is taken.
-    :type base_url: str or None
+    """ Service class that provides images from a Geopedia vector layer.
     """
     def __init__(self, **kwargs):
+        """
+        :param base_url: Base url of Geopedia REST services. If `None`, the url
+                     specified in the configuration file is taken.
+        :type base_url: str or None
+        """
         super().__init__(**kwargs)
 
         self.gpd_iterator = None
 
     def get_request(self, request):
-        """Get a list of DownloadRequests for all data that are under the given field in the table of a Geopedia layer.
+        """ Get a list of DownloadRequests for all data that are under the given field in the table of a Geopedia layer.
 
         :return: list of items which have to be downloaded
         :rtype: list(DownloadRequest)
@@ -311,8 +315,7 @@ class GeopediaImageService(GeopediaService):
         return filename
 
     def get_gpd_iterator(self):
-        """Returns iterator over info about data used for the
-        GeopediaVectorRequest
+        """ Returns iterator over info about data used for the `GeopediaVectorRequest`
 
         :return: Iterator of dictionaries containing info about data used in the request.
         :rtype: Iterator[dict] or None
@@ -321,26 +324,27 @@ class GeopediaImageService(GeopediaService):
 
 
 class GeopediaFeatureIterator(GeopediaService):
-    """Iterator for Geopedia Vector Service
-
-    :param layer: Geopedia layer which contains requested data
-    :type layer: str
-    :param bbox: Bounding box of the requested image. Its coordinates must be
-                 in the CRS.POP_WEB (EPSG:3857) coordinate system.
-    :type bbox: BBox
-    :param query_filter: Query string used for filtering returned features.
-    :type query_filter: str
-    :param gpd_session: Optional parameter for specifying a custom Geopedia session, which can also contain login
-        credentials. This can be used for accessing private Geopedia layers. By default it is set to `None` and a basic
-        Geopedia session without credentials will be created.
-    :type gpd_session: GeopediaSession or None
-    :param base_url: Base url of Geopedia REST services. If `None`, the url specified in the configuration
-        file is taken.
-    :type base_url: str or None
+    """ Iterator for Geopedia Vector Service
     """
     FILTER_EXPRESSION = 'filterExpression'
 
     def __init__(self, layer, bbox=None, query_filter=None, gpd_session=None, **kwargs):
+        """
+        :param layer: Geopedia layer which contains requested data
+        :type layer: str
+        :param bbox: Bounding box of the requested image. Its coordinates must be in the CRS.POP_WEB (EPSG:3857)
+            coordinate system.
+        :type bbox: BBox
+        :param query_filter: Query string used for filtering returned features.
+        :type query_filter: str
+        :param gpd_session: Optional parameter for specifying a custom Geopedia session, which can also contain login
+            credentials. This can be used for accessing private Geopedia layers. By default it is set to `None` and a
+            basic Geopedia session without credentials will be created.
+        :type gpd_session: GeopediaSession or None
+        :param base_url: Base url of Geopedia REST services. If `None`, the url specified in the configuration
+            file is taken.
+        :type base_url: str or None
+        """
         super().__init__(**kwargs)
 
         self.layer = self._parse_layer(layer)

--- a/sentinelhub/geopedia.py
+++ b/sentinelhub/geopedia.py
@@ -19,7 +19,7 @@ LOGGER = logging.getLogger(__name__)
 class GeopediaService:
     """ The class for Geopedia OGC services
 
-    :param base_url: Base url of Geopedia REST services. If ``None``, the url specified in the configuration
+    :param base_url: Base url of Geopedia REST services. If `None`, the url specified in the configuration
                     file is taken.
     :type base_url: str or None
     """
@@ -210,7 +210,7 @@ class GeopediaWmsService(GeopediaService, OgcImageService):
     """Geopedia OGC services class for providing image data. Most of the methods are inherited from
     `sentinelhub.ogc.OgcImageService` class.
 
-    :param base_url: Base url of Geopedia WMS services. If ``None``, the url specified in the configuration
+    :param base_url: Base url of Geopedia WMS services. If `None`, the url specified in the configuration
                     file is taken.
     :type base_url: str or None
     """
@@ -246,7 +246,7 @@ class GeopediaWmsService(GeopediaService, OgcImageService):
 class GeopediaImageService(GeopediaService):
     """Service class that provides images from a Geopedia vector layer.
 
-    :param base_url: Base url of Geopedia REST services. If ``None``, the url
+    :param base_url: Base url of Geopedia REST services. If `None`, the url
                      specified in the configuration file is taken.
     :type base_url: str or None
     """
@@ -334,7 +334,7 @@ class GeopediaFeatureIterator(GeopediaService):
         credentials. This can be used for accessing private Geopedia layers. By default it is set to `None` and a basic
         Geopedia session without credentials will be created.
     :type gpd_session: GeopediaSession or None
-    :param base_url: Base url of Geopedia REST services. If ``None``, the url specified in the configuration
+    :param base_url: Base url of Geopedia REST services. If `None`, the url specified in the configuration
         file is taken.
     :type base_url: str or None
     """

--- a/sentinelhub/io_utils.py
+++ b/sentinelhub/io_utils.py
@@ -32,7 +32,7 @@ def read_data(filename, data_format=None):
 
     :param filename: filename to read data from
     :type filename: str
-    :param data_format: format of filename. Default is ``None``
+    :param data_format: format of filename. Default is `None`
     :type data_format: MimeType
     :return: data read from filename
     :raises: exception if filename does not exist
@@ -165,11 +165,11 @@ def write_data(filename, data, data_format=None, compress=False, add=False):
     :type filename: str
     :param data: image data to write to file
     :type data: numpy array
-    :param data_format: format of output file. Default is ``None``
+    :param data_format: format of output file. Default is `None`
     :type data_format: MimeType
-    :param compress: whether to compress data or not. Default is ``False``
+    :param compress: whether to compress data or not. Default is `False`
     :type compress: bool
-    :param add: whether to append to existing text file or not. Default is ``False``
+    :param add: whether to append to existing text file or not. Default is `False`
     :type add: bool
     :raises: exception if numpy format is not supported or file cannot be written
     """
@@ -203,7 +203,7 @@ def write_tiff_image(filename, image, compress=False):
     :type filename: str
     :param image: image data to write to file
     :type image: numpy array
-    :param compress: whether to compress data. If ``True``, lzma compression is used. Default is ``False``
+    :param compress: whether to compress data. If `True`, lzma compression is used. Default is `False`
     :type compress: bool
     """
     if compress:
@@ -247,7 +247,7 @@ def write_text(filename, data, add=False):
     :type filename: str
     :param data: image data to write to text file
     :type data: numpy array
-    :param add: whether to append to existing file or not. Default is ``False``
+    :param add: whether to append to existing file or not. Default is `False`
     :type add: bool
     """
     write_type = 'a' if add else 'w'

--- a/sentinelhub/io_utils.py
+++ b/sentinelhub/io_utils.py
@@ -1,6 +1,7 @@
 """
-Module for local reading and writing of data
+Utility functions to read/write image data from/to file
 """
+
 import csv
 import json
 import os
@@ -320,7 +321,7 @@ def get_data_format(filename):
 
 
 def get_jp2_bit_depth(stream):
-    """Reads bit encoding depth of jpeg2000 file in binary stream format
+    """ Reads bit encoding depth of jpeg2000 file in binary stream format
 
     :param stream: binary stream format
     :type stream: Binary I/O (e.g. io.BytesIO, io.BufferedReader, ...)
@@ -342,7 +343,7 @@ def get_jp2_bit_depth(stream):
 
 
 def fix_jp2_image(image, bit_depth):
-    """Because Pillow library incorrectly reads JPEG 2000 images with 15-bit encoding this function corrects the
+    """ Because Pillow library incorrectly reads JPEG 2000 images with 15-bit encoding this function corrects the
     values in image.
 
     :param image: image read by opencv library

--- a/sentinelhub/ogc.py
+++ b/sentinelhub/ogc.py
@@ -24,10 +24,10 @@ LOGGER = logging.getLogger(__name__)
 class OgcService:
     """ The base class for Sentinel Hub OGC services
 
-    :param base_url: base url of Sentinel Hub's OGC services. If ``None``, the url specified in the configuration
+    :param base_url: base url of Sentinel Hub's OGC services. If `None`, the url specified in the configuration
                     file is taken.
     :type base_url: str or None
-    :param instance_id: user's instance id granting access to Sentinel Hub's OGC services. If ``None``, the instance id
+    :param instance_id: user's instance id granting access to Sentinel Hub's OGC services. If `None`, the instance id
                         specified in the configuration file is taken.
     :type instance_id: str or None
     """
@@ -72,7 +72,7 @@ class OgcService:
         :type product_id: str
         :param data_source: One of the supported Sentinel-1 data sources
         :type data_source: constants.DataSource
-        :return: True if data_source contains product_id and False otherwise
+        :return: `True` if data_source contains product_id and `False` otherwise
         :rtype: bool
         """
         props = product_id.split('_')
@@ -89,10 +89,10 @@ class OgcImageService(OgcService):
     Intermediate layer between QGC-type requests (WmsRequest and WcsRequest) and the Sentinel Hub OGC (WMS and WCS)
     services.
 
-    :param base_url: base url of Sentinel Hub's OGC services. If ``None``, the url specified in the configuration
+    :param base_url: base url of Sentinel Hub's OGC services. If `None`, the url specified in the configuration
                     file is taken.
     :type base_url: str or None
-    :param instance_id: user's instance id granting access to Sentinel Hub's OGC services. If ``None``, the instance id
+    :param instance_id: user's instance id granting access to Sentinel Hub's OGC services. If `None`, the instance id
                         specified in the configuration file is taken.
     :type instance_id: str or None
     """
@@ -478,10 +478,10 @@ class WebFeatureService(OgcService):
     :type data_source: constants.DataSource
     :param maxcc: Maximum accepted cloud coverage of an image. Float between 0.0 and 1.0. Default is 1.0.
     :type maxcc: float
-    :param base_url: base url of Sentinel Hub's OGC services. If ``None``, the url specified in the configuration
+    :param base_url: base url of Sentinel Hub's OGC services. If `None`, the url specified in the configuration
                     file is taken.
     :type base_url: str or None
-    :param instance_id: user's instance id granting access to Sentinel Hub's OGC services. If ``None``, the instance id
+    :param instance_id: user's instance id granting access to Sentinel Hub's OGC services. If `None`, the instance id
                         specified in the configuration file is taken.
     :type instance_id: str or None
     """
@@ -588,7 +588,7 @@ class WebFeatureService(OgcService):
         """ Extracts tile name, data and AWS index from tile URL
 
         :param tile_url: Location of tile at AWS
-        :type: tile_url: str
+        :type tile_url: str
         :return: Tuple in a form (tile_name, date, aws_index)
         :rtype: (str, str, int)
         """

--- a/sentinelhub/ogc.py
+++ b/sentinelhub/ogc.py
@@ -23,15 +23,16 @@ LOGGER = logging.getLogger(__name__)
 
 class OgcService:
     """ The base class for Sentinel Hub OGC services
-
-    :param base_url: base url of Sentinel Hub's OGC services. If `None`, the url specified in the configuration
-                    file is taken.
-    :type base_url: str or None
-    :param instance_id: user's instance id granting access to Sentinel Hub's OGC services. If `None`, the instance id
-                        specified in the configuration file is taken.
-    :type instance_id: str or None
     """
     def __init__(self, base_url=None, instance_id=None):
+        """
+        :param base_url: base url of Sentinel Hub's OGC services. If `None`, the url specified in the configuration
+                    file is taken.
+        :type base_url: str or None
+        :param instance_id: user's instance id granting access to Sentinel Hub's OGC services. If `None`, the instance
+            ID specified in the configuration file is taken.
+        :type instance_id: str or None
+        """
         self.base_url = SHConfig().ogc_base_url if not base_url else base_url
         self.instance_id = SHConfig().instance_id if not instance_id else instance_id
 
@@ -42,8 +43,7 @@ class OgcService:
 
     @staticmethod
     def _filter_dates(dates, time_difference):
-        """
-        Filters out dates within time_difference, preserving only the oldest date.
+        """ Filters out dates within time_difference, preserving only the oldest date.
 
         :param dates: a list of datetime objects
         :param time_difference: a ``datetime.timedelta`` representing the time difference threshold
@@ -66,7 +66,7 @@ class OgcService:
 
     @staticmethod
     def _sentinel1_product_check(product_id, data_source):
-        """Checks if Sentinel-1 product ID matches Sentinel-1 DataSource configuration
+        """ Checks if Sentinel-1 product ID matches Sentinel-1 DataSource configuration
 
         :param product_id: Sentinel-1 product ID
         :type product_id: str
@@ -88,15 +88,16 @@ class OgcImageService(OgcService):
 
     Intermediate layer between QGC-type requests (WmsRequest and WcsRequest) and the Sentinel Hub OGC (WMS and WCS)
     services.
-
-    :param base_url: base url of Sentinel Hub's OGC services. If `None`, the url specified in the configuration
-                    file is taken.
-    :type base_url: str or None
-    :param instance_id: user's instance id granting access to Sentinel Hub's OGC services. If `None`, the instance id
-                        specified in the configuration file is taken.
-    :type instance_id: str or None
     """
     def __init__(self, **kwargs):
+        """
+        :param base_url: base url of Sentinel Hub's OGC services. If `None`, the url specified in the configuration
+                    file is taken.
+        :type base_url: str or None
+        :param instance_id: user's instance id granting access to Sentinel Hub's OGC services. If `None`, the instance
+            ID specified in the configuration file is taken.
+        :type instance_id: str or None
+        """
         super().__init__(**kwargs)
 
         self.wfs_iterator = None
@@ -210,7 +211,7 @@ class OgcImageService(OgcService):
 
     @staticmethod
     def _get_wms_wcs_url_parameters(request, date):
-        """  Returns parameters common dictionary for WMS and WCS request.
+        """ Returns parameters common dictionary for WMS and WCS request.
 
         :param request: OGC-type request with specified bounding box, cloud coverage for specific product.
         :type request: OgcRequest or GeopediaRequest
@@ -433,8 +434,7 @@ class OgcImageService(OgcService):
 
     @staticmethod
     def get_image_dimensions(request):
-        """
-        Verifies or calculates image dimensions.
+        """ Verifies or calculates image dimensions.
 
         :param request: OGC-type request
         :type request: WmsRequest or WcsRequest
@@ -454,7 +454,7 @@ class OgcImageService(OgcService):
         raise ValueError("Parameters 'width' and 'height' must be integers or None")
 
     def get_wfs_iterator(self):
-        """Returns iterator over info about all satellite tiles used for the request
+        """ Returns iterator over info about all satellite tiles used for the request
 
         :return: Iterator of dictionaries containing info about all satellite tiles used in the request. In case of
                  DataSource.DEM it returns None.
@@ -464,28 +464,30 @@ class OgcImageService(OgcService):
 
 
 class WebFeatureService(OgcService):
-    """Class for interaction with Sentinel Hub WFS service
+    """ Class for interaction with Sentinel Hub WFS service
 
     The class is an iterator over info data of all available satellite tiles for requested parameters. It collects data
     from Sentinel Hub service only during the first iteration. During next iterations it returns already obtained data.
     The data is in the order returned by Sentinel Hub WFS service.
-
-    :param bbox: Bounding box of the requested image. Coordinates must be in the specified coordinate reference system.
-    :type bbox: geometry.BBox
-    :param time_interval: interval with start and end date of the form YYYY-MM-DDThh:mm:ss or YYYY-MM-DD
-    :type time_interval: (str, str)
-    :param data_source: Source of requested satellite data. Default is Sentinel-2 L1C data.
-    :type data_source: constants.DataSource
-    :param maxcc: Maximum accepted cloud coverage of an image. Float between 0.0 and 1.0. Default is 1.0.
-    :type maxcc: float
-    :param base_url: base url of Sentinel Hub's OGC services. If `None`, the url specified in the configuration
-                    file is taken.
-    :type base_url: str or None
-    :param instance_id: user's instance id granting access to Sentinel Hub's OGC services. If `None`, the instance id
-                        specified in the configuration file is taken.
-    :type instance_id: str or None
     """
     def __init__(self, bbox, time_interval, *, data_source=DataSource.SENTINEL2_L1C, maxcc=1.0, **kwargs):
+        """
+        :param bbox: Bounding box of the requested image. Coordinates must be in the specified coordinate reference
+            system.
+        :type bbox: geometry.BBox
+        :param time_interval: interval with start and end date of the form YYYY-MM-DDThh:mm:ss or YYYY-MM-DD
+        :type time_interval: (str, str)
+        :param data_source: Source of requested satellite data. Default is Sentinel-2 L1C data.
+        :type data_source: constants.DataSource
+        :param maxcc: Maximum accepted cloud coverage of an image. Float between 0.0 and 1.0. Default is 1.0.
+        :type maxcc: float
+        :param base_url: base url of Sentinel Hub's OGC services. If `None`, the url specified in the configuration
+                        file is taken.
+        :type base_url: str or None
+        :param instance_id: user's instance id granting access to Sentinel Hub's OGC services. If `None`, the instance
+            ID specified in the configuration file is taken.
+        :type instance_id: str or None
+        """
         super().__init__(**kwargs)
 
         self.bbox = bbox
@@ -498,7 +500,7 @@ class WebFeatureService(OgcService):
         self.feature_offset = 0
 
     def __iter__(self):
-        """Iteration method
+        """ Iteration method
 
         :return: iterator of dictionaries containing info about product tiles
         :rtype: Iterator[dict]
@@ -507,7 +509,7 @@ class WebFeatureService(OgcService):
         return self
 
     def __next__(self):
-        """Next method
+        """ Next method
 
         :return: dictionary containing info about product tiles
         :rtype: dict
@@ -522,7 +524,7 @@ class WebFeatureService(OgcService):
         raise StopIteration
 
     def _fetch_features(self):
-        """Collects data from WFS service
+        """ Collects data from WFS service
 
         :return: dictionary containing info about product tiles
         :rtype: dict

--- a/sentinelhub/opensearch.py
+++ b/sentinelhub/opensearch.py
@@ -27,7 +27,7 @@ def get_tile_info_id(tile_id):
     :param tile_id: original tile identification string provided by ESA (e.g.
                     'S2A_OPER_MSI_L1C_TL_SGS__20160109T230542_A002870_T10UEV_N02.01')
     :type tile_id: str
-    :return: dictionary with info provided by Opensearch REST service or ``None`` if such tile does not exist on AWS.
+    :return: dictionary with info provided by Opensearch REST service or `None` if such tile does not exist on AWS.
     :rtype: dict or None
     :raises: TileMissingException if no tile with tile ID `tile_id` exists
     """
@@ -51,9 +51,9 @@ def get_tile_info(tile, time, aws_index=None, all_tiles=False):
     :type time: str or (str, str)
     :param aws_index: index of tile on AWS
     :type aws_index: int or None
-    :param all_tiles: If ``True`` it will return list of all tiles otherwise only the first one
+    :param all_tiles: If `True` it will return list of all tiles otherwise only the first one
     :type all_tiles: bool
-    :return: dictionary with info provided by Opensearch REST service or None if such tile does not exist on AWS.
+    :return: dictionary with info provided by Opensearch REST service or `None` if such tile does not exist on AWS.
     :rtype: dict or None
     """
     start_date, end_date = parse_time_interval(time)

--- a/sentinelhub/opensearch.py
+++ b/sentinelhub/opensearch.py
@@ -1,5 +1,6 @@
 """
 Module for communication with http://opensearch.sentinel-hub.com/resto/api
+
 For more search parameters check: http://opensearch.sentinel-hub.com/resto/api/collections/Sentinel2/describe.xml
 """
 

--- a/sentinelhub/os_utils.py
+++ b/sentinelhub/os_utils.py
@@ -104,7 +104,7 @@ def size(pathname):
 
 
 def sys_is_windows():
-    """Check if user is running the code on Windows machine
+    """ Check if user is running the code on Windows machine
 
     :return: `True` if OS is Windows and `False` otherwise
     :rtype: bool

--- a/sentinelhub/os_utils.py
+++ b/sentinelhub/os_utils.py
@@ -78,7 +78,7 @@ def rename(old_path, new_path, edit_folders=True):
 
     :param old_path: name of file or folder to rename
     :param new_path: name of new file or folder
-    :param edit_folders: flag to allow recursive renaming of folders. Default is ``True``
+    :param edit_folders: flag to allow recursive renaming of folders. Default is `True`
     :type old_path: str
     :type new_path: str
     :type edit_folders: bool
@@ -106,7 +106,7 @@ def size(pathname):
 def sys_is_windows():
     """Check if user is running the code on Windows machine
 
-    :return: True if OS is Windows and False otherwise
+    :return: `True` if OS is Windows and `False` otherwise
     :rtype: bool
     """
     return platform.lower().startswith('win')

--- a/sentinelhub/test_utils.py
+++ b/sentinelhub/test_utils.py
@@ -1,5 +1,5 @@
 """
-Implements utilities for writing unit tests on satellite data
+Utility tools for writing unit tests for packages which rely on `sentinelhub-py`
 """
 
 import unittest

--- a/sentinelhub/time_utils.py
+++ b/sentinelhub/time_utils.py
@@ -76,7 +76,7 @@ def datetime_to_iso(date, only_date=True):
 
     :param date: datetime instance to convert
     :type date: datetime
-    :param only_date: whether to return date only or also time information. Default is ``True``
+    :param only_date: whether to return date only or also time information. Default is `True`
     :type only_date: bool
     :return: date in ISO 8601 format
     :rtype: str
@@ -100,7 +100,7 @@ def is_valid_time(time):
 
     :param time: a string containing a time/date stamp
     :type time: str
-    :return: ``True`` is string is a valid time/date stamp, ``False`` otherwise
+    :return: `True` is string is a valid time/date stamp, `False` otherwise
     :rtype: bool
     """
     try:


### PR DESCRIPTION
Changes:
- A lot of docs strings have been slightly modified - I tried to set them to a more strict common form.
- In rst files documenting each package module I replaced lists of classes with `automodule`.
- A few other improvements of how documentation is created.

There is still 1 problem in `areas` module where Sphinx doesn't want to add `AreaSplitter` content in documentation. Switching to `automodule` doesn't work either. It might be a bug in Sphinx. At the moment probably isn't worth spending anymore time for this.

This PR includes changes from PR #68 and should be merged after that one.