### PR TITLE
threads by default is #processes multiplied by 5

### DIFF
--- a/sentinelhub/data_request.py
+++ b/sentinelhub/data_request.py
@@ -95,7 +95,7 @@ class DataRequest(ABC):
             ``data_filter=[0, 2, -1]`` the method will return only 1st, 3rd and last item. Default filter is `None`.
         :type data_filter: list(int) or None
         :param max_threads: number of threads to use when downloading data; default is ``max_threads=None`` which
-            by default uses the number of processors on the system
+            by default uses the number of processors on the system multiplied by 5.
         :type max_threads: int
         :param raise_download_errors: If `True` any error in download process should be raised as
             ``DownloadFailedException``. If `False` failed downloads will only raise warnings and the method will
@@ -118,7 +118,7 @@ class DataRequest(ABC):
         :param redownload: data is redownloaded if ``redownload=True``. Default is `False`
         :type redownload: bool
         :param max_threads: number of threads to use when downloading data; default is ``max_threads=None`` which
-            by default uses the number of processors on the system
+            by default uses the number of processors on the system multiplied by 5.
         :type max_threads: int
         :param raise_download_errors: If `True` any error in download process should be raised as
             ``DownloadFailedException``. If `False` failed downloads will only raise warnings.

--- a/sentinelhub/download.py
+++ b/sentinelhub/download.py
@@ -179,7 +179,7 @@ def download_data(request_list, redownload=False, max_threads=None):
                         on the disk. Default is `False`.
     :type redownload: bool
     :param max_threads: number of threads to use when downloading data; default is ``max_threads=None`` which
-            by default uses the number of processors on the system
+            by default uses the number of processors on the system multiplied by 5.
     :type max_threads: int
     :return: list of Futures holding downloaded data, where each element in the list corresponds to an element
                 in the download request list.


### PR DESCRIPTION
Number of threads started for a request is by default (None) number of processes multiplied by 5, see
https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.ThreadPoolExecutor