### PR TITLE
Fix/crs repr

### DIFF
--- a/sentinelhub/constants.py
+++ b/sentinelhub/constants.py
@@ -293,6 +293,11 @@ class CRS(Enum, metaclass=CRSMeta):
         """
         return self.ogc_string()
 
+    def __repr__(self):
+        """ Method for retrieving CRS enum representation
+        """
+        return "CRS('{}')".format(self.value)
+
     @classmethod
     def has_value(cls, value):
         """ Tests whether CRS contains a constant defined with string `value`.

--- a/sentinelhub/geometry.py
+++ b/sentinelhub/geometry.py
@@ -145,7 +145,7 @@ class BBox(BaseGeometry):
     def __repr__(self):
         """ Class representation
         """
-        return '{}((({}, {}), ({}, {})), crs={})'.format(self.__class__.__name__, *self, self.crs)
+        return '{}((({}, {}), ({}, {})), crs={})'.format(self.__class__.__name__, *self, repr(self.crs))
 
     def __str__(self, reverse=False):
         """ Transforms bounding box into a string of coordinates

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -34,6 +34,21 @@ class TestCRS(TestSentinelHub):
                 ogc_str = CRS.ogc_string(crs)
                 self.assertEqual(epsg, ogc_str, msg="Expected {}, got {}".format(epsg, ogc_str))
 
+    def test_repr(self):
+        crs_values = (
+            (CRS.POP_WEB, "CRS('3857')"),
+            (CRS.WGS84, "CRS('4326')"),
+            (CRS.UTM_33N, "CRS('32633')"),
+            (CRS.UTM_33S, "CRS('32733')"),
+            (CRS('3857'), "CRS('3857')"),
+            (CRS('4326'), "CRS('4326')"),
+            (CRS('32633'), "CRS('32633')"),
+            (CRS('32733'), "CRS('32733')"),
+        )
+        for crs, crs_repr in crs_values:
+            with self.subTest(msg=crs_repr):
+                self.assertEqual(crs_repr, repr(crs), msg="Expected {}, got {}".format(crs_repr, repr(crs)))
+
     def test_has_value(self):
         for crs in CRS:
             self.assertTrue(CRS.has_value(crs.value), msg="Expected support for CRS {}".format(crs.value))

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -104,6 +104,13 @@ class TestBBox(TestSentinelHub):
         self.assertEqual(str(bbox), expect_str,
                          msg="String representations not matching: expected {}, got {}".format(expect_str, str(bbox)))
 
+    def test_bbox_to_repr(self):
+        x1, y1, x2, y2 = 45.0, 12.0, 47.0, 14.0
+        bbox = BBox(((x1, y1), (x2, y2)), crs=CRS('4326'))
+        expect_repr = "BBox((({}, {}), ({}, {})), crs=CRS('4326'))".format(x1, y1, x2, y2)
+        self.assertEqual(repr(bbox), expect_repr,
+                         msg="String representations not matching: expected {}, got {}".format(expect_repr, repr(bbox)))
+
     def test_bbox_iter(self):
         bbox_lst = [46.07, 13.23, 46.24, 13.57]
         bbox = BBox(bbox_lst, CRS.WGS84)


### PR DESCRIPTION
This PR fixes `repr()` of `CRS` and `BBox`. In Python, `repr()` should output the code that would create an equal object, which it didn't.

Before:
```
>>> bbox = BBox(bbox=[46.16, -16.15, 46.51, -15.58], crs=CRS.WGS84)
>>> print(repr(bbox))
BBox(((46.16, -16.15), (46.51, -15.58)), crs=EPSG:4326)
>>> bbox = BBox(((46.16, -16.15), (46.51, -15.58)), crs=EPSG:4326)
  File "<stdin>", line 1
    bbox = BBox(((46.16, -16.15), (46.51, -15.58)), crs=EPSG:4326)
                                                            ^
SyntaxError: invalid syntax
```

After:
```
>>> bbox = BBox(bbox=[46.16, -16.15, 46.51, -15.58], crs=CRS.WGS84)
>>> print(repr(bbox))
BBox(((46.16, -16.15), (46.51, -15.58)), crs=CRS('4326'))
>>> bbox = BBox(((46.16, -16.15), (46.51, -15.58)), crs=CRS('4326'))
```

Let me know if anything should be done differently, or just edit as you see fit.