### PR TITLE
Minor typo fixes found with codespell

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Makefile for creating a new release of the package and uploading it to PyPI
-# This way is prefered to manual because it also resets config.json
+# This way is preferred to manual because it also resets config.json
 
 PYTHON = python3
 CONFIG = sentinelhub.config

--- a/examples/aws_request.ipynb
+++ b/examples/aws_request.ipynb
@@ -43,7 +43,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note: `matplotlib` is not a dependecy of `sentinelhub` and is used in these examples for visualizations."
+    "Note: `matplotlib` is not a dependency of `sentinelhub` and is used in these examples for visualizations."
    ]
   },
   {

--- a/examples/large_area_utilities.ipynb
+++ b/examples/large_area_utilities.ipynb
@@ -58,7 +58,7 @@
     "import matplotlib.pyplot as plt\n",
     "from matplotlib.patches import Polygon as plt_polygon\n",
     "\n",
-    "from mpl_toolkits.basemap import Basemap  # Avaliable here: https://github.com/matplotlib/basemap"
+    "from mpl_toolkits.basemap import Basemap  # Available here: https://github.com/matplotlib/basemap"
    ]
   },
   {

--- a/sentinelhub/constants.py
+++ b/sentinelhub/constants.py
@@ -669,7 +669,7 @@ class OgcConstants:
 class AwsConstants:
     """ Initialisation of every constant used by AWS classes
 
-    For each supported data source it contains lists of all possible bands and all posible metadata files:
+    For each supported data source it contains lists of all possible bands and all possible metadata files:
 
         - S2_L1C_BANDS and S2_L1C_METAFILES
         - S2_L2A_BANDS and S2_L2A_METAFILES

--- a/sentinelhub/data_request.py
+++ b/sentinelhub/data_request.py
@@ -251,7 +251,7 @@ class OgcRequest(DataRequest):
     :param bbox: Bounding box of the requested image. Coordinates must be in the specified coordinate reference system.
     :type bbox: geometry.BBox
     :param time: time or time range for which to return the results, in ISO8601 format
-                (year-month-date, for example: ``2016-01-01``, or year-month-dateThours:minuts:seconds format,
+                (year-month-date, for example: ``2016-01-01``, or year-month-dateThours:minutes:seconds format,
                 i.e. ``2016-01-01T16:31:21``). When a single time is specified the request will return
                 data for that specific date, if it exists. If a time range is specified the result is a list of all
                 scenes between the specified dates conforming to the cloud coverage criteria. Most recent acquisition
@@ -386,7 +386,7 @@ class WmsRequest(OgcRequest):
     :param bbox: Bounding box of the requested image. Coordinates must be in the specified coordinate reference system.
     :type bbox: geometry.BBox
     :param time: time or time range for which to return the results, in ISO8601 format
-                (year-month-date, for example: ``2016-01-01``, or year-month-dateThours:minuts:seconds format,
+                (year-month-date, for example: ``2016-01-01``, or year-month-dateThours:minutes:seconds format,
                 i.e. ``2016-01-01T16:31:21``). When a single time is specified the request will return
                 data for that specific date, if it exists. If a time range is specified the result is a list of all
                 scenes between the specified dates conforming to the cloud coverage criteria. Most recent acquisition
@@ -453,7 +453,7 @@ class WcsRequest(OgcRequest):
     :param bbox: Bounding box of the requested image. Coordinates must be in the specified coordinate reference system.
     :type bbox: geometry.BBox
     :param time: time or time range for which to return the results, in ISO8601 format
-                (year-month-date, for example: ``2016-01-01``, or year-month-dateThours:minuts:seconds format,
+                (year-month-date, for example: ``2016-01-01``, or year-month-dateThours:minutes:seconds format,
                 i.e. ``2016-01-01T16:31:21``). When a single time is specified the request will return
                 data for that specific date, if it exists. If a time range is specified the result is a list of all
                 scenes between the specified dates conforming to the cloud coverage criteria. Most recent acquisition
@@ -512,7 +512,7 @@ class FisRequest(OgcRequest):
         match the one given by `data_source` parameter
     :type layer: str
     :param time: time or time range for which to return the results, in ISO8601 format
-        (year-month-date, for example: ``2016-01-01``, or year-month-dateThours:minuts:seconds format,
+        (year-month-date, for example: ``2016-01-01``, or year-month-dateThours:minutes:seconds format,
         i.e. ``2016-01-01T16:31:21``). Examples: ``'2016-01-01'``, or ``('2016-01-01', ' 2016-01-31')``
     :type time: str or (str, str) or datetime.date or (datetime.date, datetime.date) or datetime.datetime or
         (datetime.datetime, datetime.datetime)
@@ -740,7 +740,7 @@ class AwsRequest(DataRequest):
                       (e.g. ``['metadata', 'tileInfo', 'preview/B01', 'TCI']``)
     :type metafiles: list(str)
     :param safe_format: flag that determines the structure of saved data. If `True` it will be saved in .SAFE format
-                        defined by ESA. If `False` it will be saved in the same structure as the stucture at AWS.
+                        defined by ESA. If `False` it will be saved in the same structure as the structure at AWS.
     :type safe_format: bool
     :param data_folder: location of the directory where the fetched data will be saved.
     :type data_folder: str
@@ -783,7 +783,7 @@ class AwsProductRequest(AwsRequest):
                       (e.g. ``['metadata', 'tileInfo', 'preview/B01', 'TCI']``)
     :type metafiles: list(str)
     :param safe_format: flag that determines the structure of saved data. If `True` it will be saved in .SAFE format
-                        defined by ESA. If `False` it will be saved in the same structure as the stucture at AWS.
+                        defined by ESA. If `False` it will be saved in the same structure as the structure at AWS.
     :type safe_format: bool
     :param data_folder: location of the directory where the fetched data will be saved.
     :type data_folder: str
@@ -829,7 +829,7 @@ class AwsTileRequest(AwsRequest):
                       (e.g. ``['metadata', 'tileInfo', 'preview/B01', 'TCI']``)
     :type metafiles: list(str)
     :param safe_format: flag that determines the structure of saved data. If `True` it will be saved in .SAFE format
-                        defined by ESA. If `False` it will be saved in the same structure as the stucture at AWS.
+                        defined by ESA. If `False` it will be saved in the same structure as the structure at AWS.
     :type safe_format: bool
     :param data_folder: location of the directory where the fetched data will be saved.
     :type data_folder: str


### PR DESCRIPTION
Used this by hand (not the `-w` option)

```
codespell --version
1.15.0
```