### PR TITLE
WIP: fix updating with other_args dict

### DIFF
--- a/sentinelhub/sentinelhub_request.py
+++ b/sentinelhub/sentinelhub_request.py
@@ -10,6 +10,14 @@ from .geometry import Geometry, BBox
 from .time_utils import parse_time_interval
 
 
+def update_other_args(d, u):
+    for k, v in u.items():
+        if isinstance(v, dict):
+            update_other_args(d[k], v)
+        else:
+            d[k] = v
+
+
 class SentinelHubRequest(DataRequest):
     """ Sentinel Hub API request class
     """
@@ -123,7 +131,7 @@ class SentinelHubRequest(DataRequest):
             input_data_object['dataFilter']['collectionId'] = data_source.value
 
         if other_args:
-            input_data_object.update(other_args)
+            update_other_args(input_data_object, other_args)
 
         return input_data_object
 
@@ -155,7 +163,7 @@ class SentinelHubRequest(DataRequest):
             request_body['output'] = request_output
 
         if other_args:
-            request_body.update(other_args)
+            update_other_args(request_body, other_args)
 
         return request_body
 
@@ -179,7 +187,7 @@ class SentinelHubRequest(DataRequest):
         }
 
         if other_args:
-            output_response.update(other_args)
+            update_other_args(output_response, other_args)
 
         return output_response
 
@@ -210,7 +218,7 @@ class SentinelHubRequest(DataRequest):
             request_output['resx'], request_output['resy'] = resolution
 
         if other_args:
-            request_output.update(other_args)
+            update_other_args(request_output, other_args)
 
         return request_output
 
@@ -256,6 +264,6 @@ class SentinelHubRequest(DataRequest):
             request_bounds['geometry'] = geometry.geojson
 
         if other_args:
-            request_bounds.update(other_args)
+            update_other_args(request_bounds, other_args)
 
         return request_bounds

--- a/sentinelhub/sentinelhub_request.py
+++ b/sentinelhub/sentinelhub_request.py
@@ -10,12 +10,16 @@ from .geometry import Geometry, BBox
 from .time_utils import parse_time_interval
 
 
-def update_other_args(d, u):
-    for k, v in u.items():
-        if isinstance(v, dict):
-            update_other_args(d[k], v)
+def update_other_args(dict1, dict2):
+    """
+    Function for a recursive update of `dict1` with `dict2`. The function loops over the keys in `dict2` and
+    only the non-dict like values are assigned to the specified keys.
+    """
+    for key, value in dict2.items():
+        if isinstance(value, dict):
+            update_other_args(dict1[key], value)
         else:
-            d[k] = v
+            dict1[key] = value
 
 
 class SentinelHubRequest(DataRequest):

--- a/sentinelhub/sentinelhub_request.py
+++ b/sentinelhub/sentinelhub_request.py
@@ -16,8 +16,11 @@ def _update_other_args(dict1, dict2):
     only the non-dict like values are assigned to the specified keys.
     """
     for key, value in dict2.items():
-        if isinstance(value, dict):
-            _update_other_args(dict1[key], value)
+        if key in dict1.keys():
+            if isinstance(value, dict):
+                _update_other_args(dict1[key], value)
+            else:
+                dict1[key] = value
         else:
             dict1[key] = value
 

--- a/sentinelhub/sentinelhub_request.py
+++ b/sentinelhub/sentinelhub_request.py
@@ -10,14 +10,14 @@ from .geometry import Geometry, BBox
 from .time_utils import parse_time_interval
 
 
-def update_other_args(dict1, dict2):
+def _update_other_args(dict1, dict2):
     """
     Function for a recursive update of `dict1` with `dict2`. The function loops over the keys in `dict2` and
     only the non-dict like values are assigned to the specified keys.
     """
     for key, value in dict2.items():
         if isinstance(value, dict):
-            update_other_args(dict1[key], value)
+            _update_other_args(dict1[key], value)
         else:
             dict1[key] = value
 
@@ -135,7 +135,7 @@ class SentinelHubRequest(DataRequest):
             input_data_object['dataFilter']['collectionId'] = data_source.value
 
         if other_args:
-            update_other_args(input_data_object, other_args)
+            _update_other_args(input_data_object, other_args)
 
         return input_data_object
 
@@ -167,7 +167,7 @@ class SentinelHubRequest(DataRequest):
             request_body['output'] = request_output
 
         if other_args:
-            update_other_args(request_body, other_args)
+            _update_other_args(request_body, other_args)
 
         return request_body
 
@@ -191,7 +191,7 @@ class SentinelHubRequest(DataRequest):
         }
 
         if other_args:
-            update_other_args(output_response, other_args)
+            _update_other_args(output_response, other_args)
 
         return output_response
 
@@ -222,7 +222,7 @@ class SentinelHubRequest(DataRequest):
             request_output['resx'], request_output['resy'] = resolution
 
         if other_args:
-            update_other_args(request_output, other_args)
+            _update_other_args(request_output, other_args)
 
         return request_output
 
@@ -268,6 +268,6 @@ class SentinelHubRequest(DataRequest):
             request_bounds['geometry'] = geometry.geojson
 
         if other_args:
-            update_other_args(request_bounds, other_args)
+            _update_other_args(request_bounds, other_args)
 
         return request_bounds

--- a/sentinelhub/sentinelhub_request.py
+++ b/sentinelhub/sentinelhub_request.py
@@ -16,11 +16,8 @@ def _update_other_args(dict1, dict2):
     only the non-dict like values are assigned to the specified keys.
     """
     for key, value in dict2.items():
-        if key in dict1.keys():
-            if isinstance(value, dict):
-                _update_other_args(dict1[key], value)
-            else:
-                dict1[key] = value
+        if isinstance(value, dict) and key in dict1:
+            _update_other_args(dict1[key], value)
         else:
             dict1[key] = value
 


### PR DESCRIPTION
Properly update the dictionary objects when the `other_args` param is used.

The new function recursively loops over the `other_args` and only adds non-dict like values to assigned keys, meaning that you can provide a nested dictionary which will be used to update the internal dictionary object.