### PR TITLE
CRS parsing shows a warning instead of an error

### DIFF
--- a/sentinelhub/constants.py
+++ b/sentinelhub/constants.py
@@ -11,7 +11,7 @@ import utm
 import pyproj
 from aenum import extend_enum
 
-from .exceptions import SHDeprecationWarning
+from .exceptions import SHDeprecationWarning, SHUserWarning
 from ._version import __version__
 
 
@@ -91,8 +91,10 @@ class CRSMeta(EnumMeta):
             value = value['init']
         if isinstance(value, pyproj.CRS):
             if value == CRSMeta._UNSUPPORTED_CRS:
-                raise ValueError('sentinelhub-py supports only WGS 84 coordinate reference system with '
-                                 'coordinate order lng-lat. However pyproj.CRS(4326) has coordinate order lat-lng')
+                message = 'sentinelhub-py supports only WGS 84 coordinate reference system with ' \
+                          'coordinate order lng-lat. Given pyproj.CRS(4326) has coordinate order lat-lng. Be careful ' \
+                          'to use the correct order of coordinates.'
+                warnings.warn(message, category=SHUserWarning)
 
             value = value.to_epsg()
 

--- a/sentinelhub/data_collections.py
+++ b/sentinelhub/data_collections.py
@@ -492,7 +492,7 @@ class DataCollection(Enum, metaclass=_DataCollectionMeta):
             if item in definition_dict:
                 return definition_dict[item]
 
-        return super().__getattr__(item, *args, **kwargs)
+        return super().__getattribute__(item, *args, **kwargs)
 
     @property
     def is_sentinel1(self):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -9,7 +9,7 @@ class TestSHConfig(TestSentinelHub):
     def test_configuration(self):
         SHConfig().save()
 
-        config_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', 'sentinelhub', 'config.json')
+        config_file = SHConfig().get_config_location()
 
         if not os.path.isfile(config_file):
             self.fail(msg='Config file does not exist: {}'.format(os.path.abspath(config_file)))

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -4,6 +4,7 @@ import pyproj
 
 from sentinelhub import CRS, MimeType, TestSentinelHub
 from sentinelhub.constants import RequestType
+from sentinelhub.exceptions import SHUserWarning
 
 
 class TestCRS(TestSentinelHub):
@@ -38,8 +39,9 @@ class TestCRS(TestSentinelHub):
                 parsed_result = CRS(parse_value)
                 self.assertEqual(parsed_result, expected_result)
 
-        with self.assertRaises(ValueError):
-            CRS(pyproj.CRS(4326))
+        with self.assertWarns(SHUserWarning):
+            wgs84 = CRS(pyproj.CRS(4326))
+        self.assertEqual(wgs84, CRS.WGS84)
 
     def test_ogc_string(self):
         crs_values = (


### PR DESCRIPTION
When parsing `sentinelhub.CRS(pyproj.CRS(4326))` we now get a warning instead of an explicit error about the coordinate order. This way it is up to a user to correctly deal with coordinates.