### PR TITLE
Moved get_json and get_xml functions to DownloadClient methods

### DIFF
--- a/sentinelhub/aws.py
+++ b/sentinelhub/aws.py
@@ -11,7 +11,7 @@ from .config import SHConfig
 from .constants import AwsConstants, EsaSafeType, MimeType
 from .data_collections import DataCollection
 from .download import DownloadRequest
-from .download.aws_client import get_aws_json
+from .download.aws_client import AwsDownloadClient
 from .exceptions import AwsDownloadFailedException, SHUserWarning
 from .opensearch import get_tile_info, get_tile_info_id
 from .time_utils import parse_time
@@ -330,7 +330,9 @@ class AwsProduct(AwsService):
 
         self.date = self.get_date()
         self.product_url = self.get_product_url()
-        self.product_info = get_aws_json(self.get_url(AwsConstants.PRODUCT_INFO))
+
+        client = AwsDownloadClient(config=self.config)
+        self.product_info = client.get_json(self.get_url(AwsConstants.PRODUCT_INFO))
 
         self.baseline = self.get_baseline()
 
@@ -601,7 +603,8 @@ class AwsTile(AwsService):
         :return: dictionary with tile information
         :rtype: dict
         """
-        return get_aws_json(self.get_url(AwsConstants.TILE_INFO))
+        client = AwsDownloadClient(config=self.config)
+        return client.get_json(self.get_url(AwsConstants.TILE_INFO))
 
     def get_url(self, filename):
         """

--- a/sentinelhub/aws_safe.py
+++ b/sentinelhub/aws_safe.py
@@ -7,7 +7,7 @@ import warnings
 from .aws import AwsProduct, AwsTile
 from .constants import AwsConstants, EsaSafeType, MimeType
 from .data_collections import DataCollection
-from .download.aws_client import get_aws_xml
+from .download.aws_client import AwsDownloadClient
 from .exceptions import SHRuntimeWarning
 
 
@@ -145,7 +145,8 @@ class SafeProduct(AwsProduct):
         :return: String in a form YYYYMMDDTHHMMSS
         :rtype: str
         """
-        tree = get_aws_xml(self.get_url(AwsConstants.REPORT))
+        client = AwsDownloadClient(config=self.config)
+        tree = client.get_xml(self.get_url(AwsConstants.REPORT))
 
         try:
             timestamp = tree.find('check/inspection').attrib['execution']
@@ -260,7 +261,8 @@ class SafeTile(AwsTile):
         :return: ESA tile ID
         :rtype: str
         """
-        tree = get_aws_xml(self.get_url(AwsConstants.METADATA))
+        client = AwsDownloadClient(config=self.config)
+        tree = client.get_xml(self.get_url(AwsConstants.METADATA))
 
         tile_id_tag = 'TILE_ID_2A' if (self.data_collection is DataCollection.SENTINEL2_L2A
                                        and self.baseline <= '02.06') else 'TILE_ID'

--- a/sentinelhub/download/aws_client.py
+++ b/sentinelhub/download/aws_client.py
@@ -8,7 +8,7 @@ import boto3
 from botocore.exceptions import NoCredentialsError
 
 from ..exceptions import AwsDownloadFailedException
-from .client import DownloadClient, get_json, get_xml
+from .client import DownloadClient
 from .handlers import fail_missing_file
 
 
@@ -85,15 +85,3 @@ class AwsDownloadClient(DownloadClient):
         :rtype: bool
         """
         return request.url.startswith('s3://')
-
-
-def get_aws_json(*args, **kwargs):
-    """ Download a json from AWS
-    """
-    return get_json(*args, download_client_class=AwsDownloadClient, **kwargs)
-
-
-def get_aws_xml(*args, **kwargs):
-    """ Download an xml from AWS
-    """
-    return get_xml(*args, download_client_class=AwsDownloadClient, **kwargs)

--- a/sentinelhub/download/sentinelhub_client.py
+++ b/sentinelhub/download/sentinelhub_client.py
@@ -8,7 +8,7 @@ from threading import Lock, currentThread
 import requests
 
 from .handlers import fail_user_errors, retry_temporal_errors
-from .client import DownloadClient, get_json
+from .client import DownloadClient
 from ..sentinelhub_session import SentinelHubSession
 from ..sentinelhub_rate_limit import SentinelHubRateLimit
 
@@ -105,24 +105,3 @@ class SentinelHubDownloadClient(DownloadClient):
         session = SentinelHubSession(config=self.config)
         SentinelHubDownloadClient._CACHED_SESSIONS[cache_key] = session
         return session
-
-
-def get_auth_json(url, post_values=None, headers=None, request_type=None, **kwargs):
-    """ Make an authenticated request to Sentinel Hub service and obtain a JSON response. Authentication happens
-    automatically before the main request is executed.
-
-    :param url: An URL to Sentinel Hub services
-    :type url: str
-    :param post_values: A dictionary of parameters for a POST request
-    :type post_values: dict or None
-    :param headers: A dictionary of additional request headers
-    :type headers: dict or None
-    :param request_type: A type of HTTP request to make. If not specified, then it will be a GET request if
-        `post_values=None` and a POST request otherwise
-    :type request_type: RequestType or None
-    :param kwargs: Parameters that are passed to a DownloadRequest class
-    :return: JSON data parsed into Python objects
-    :rtype: object or None
-    """
-    return get_json(url, post_values=post_values, headers=headers, request_type=request_type,
-                    download_client_class=SentinelHubDownloadClient, use_session=True, **kwargs)

--- a/sentinelhub/geopedia.py
+++ b/sentinelhub/geopedia.py
@@ -10,7 +10,7 @@ from shapely.geometry import shape as geo_shape
 
 from .ogc import OgcImageService, MimeType
 from .config import SHConfig
-from .download import DownloadRequest, get_json
+from .download import DownloadRequest, DownloadClient
 from .constants import CRS
 
 LOGGER = logging.getLogger(__name__)
@@ -178,7 +178,9 @@ class GeopediaSession(GeopediaService):
 
         session_id = self._parse_session_id(self._session_info) if self._session_info else ''
         session_url = '{}/data/v1/session/create?locale=en&sid={}'.format(self._base_url, session_id)
-        self._session_info = get_json(session_url)
+
+        client = DownloadClient(config=self.config)
+        self._session_info = client.get_json(session_url)
 
         if self.username and self.password and self._parse_user_id(self._session_info) == self.UNAUTHENTICATED_USER_ID:
             self._make_login()
@@ -193,7 +195,8 @@ class GeopediaSession(GeopediaService):
         login_url = '{}/data/v1/session/login?user={}&pass={}&sid={}'.format(self._base_url, self.username,
                                                                              self.password,
                                                                              self._parse_session_id(self._session_info))
-        self._session_info = get_json(login_url)
+        client = DownloadClient(config=self.config)
+        self._session_info = client.get_json(login_url)
 
     @staticmethod
     def _parse_session_id(session_info):
@@ -388,7 +391,8 @@ class GeopediaFeatureIterator(GeopediaService):
         if self.next_page_url is None:
             return
 
-        response = get_json(self.next_page_url, post_values=self.query, headers=self.gpd_session.session_headers)
+        client = DownloadClient(config=self.config)
+        response = client.get_json(self.next_page_url, post_values=self.query, headers=self.gpd_session.session_headers)
 
         self.features.extend(response['features'])
         self.next_page_url = response['pagination']['next']

--- a/sentinelhub/ogc.py
+++ b/sentinelhub/ogc.py
@@ -13,7 +13,7 @@ from .config import SHConfig
 from .data_collections import DataCollection, handle_deprecated_data_source
 from .geo_utils import get_image_dimension
 from .geometry import BBox, Geometry
-from .download import DownloadRequest, get_json
+from .download import DownloadRequest, SentinelHubDownloadClient
 from .time_utils import parse_time_interval, filter_times
 
 LOGGER = logging.getLogger(__name__)
@@ -412,7 +412,8 @@ class WebFeatureService(OgcService):
         url = main_url + urlencode(params)
 
         LOGGER.debug("URL=%s", url)
-        response = get_json(url)
+        client = SentinelHubDownloadClient(config=self.config)
+        response = client.get_json(url)
 
         is_sentinel1 = self.data_collection.is_sentinel1
         for tile_info in response['features']:

--- a/sentinelhub/opensearch.py
+++ b/sentinelhub/opensearch.py
@@ -10,7 +10,7 @@ from urllib.parse import urlencode
 
 from .constants import CRS
 from .config import SHConfig
-from .download import get_json
+from .download import DownloadClient
 from .time_utils import parse_time_interval
 
 
@@ -157,6 +157,7 @@ def search_iter(tile_id=None, bbox=None, start_date=None, end_date=None, absolut
     url_params['maxRecords'] = config.max_opensearch_records_per_query
 
     start_index = 1
+    client = DownloadClient(config=config)
 
     while True:
         url_params['index'] = start_index
@@ -164,7 +165,7 @@ def search_iter(tile_id=None, bbox=None, start_date=None, end_date=None, absolut
         url = '{}/search.json?{}'.format(config.opensearch_url, urlencode(url_params))
         LOGGER.debug("URL=%s", url)
 
-        response = get_json(url)
+        response = client.get_json(url)
         for tile_info in response["features"]:
             yield tile_info
 

--- a/sentinelhub/sentinelhub_batch.py
+++ b/sentinelhub/sentinelhub_batch.py
@@ -5,7 +5,7 @@ from urllib.parse import urlencode
 
 from .config import SHConfig
 from .constants import RequestType
-from .download.sentinelhub_client import get_auth_json
+from .download.sentinelhub_client import SentinelHubDownloadClient
 from .geometry import Geometry, BBox, CRS
 from .sentinelhub_request import SentinelHubRequest
 
@@ -78,7 +78,9 @@ class SentinelHubBatch:
         payload = _remove_undefined_params(payload)
 
         url = cls._get_process_url(config)
-        request_info = get_auth_json(url, post_values=payload)
+        client = SentinelHubDownloadClient(config=config)
+        request_info = client.get_json(url, post_values=payload, use_session=True)
+
         return cls(request_info=request_info, config=config)
 
     @staticmethod
@@ -162,7 +164,7 @@ class SentinelHubBatch:
             'sort': sort,
             **kwargs
         })
-        return _iter_pages(url, **params)
+        return _iter_pages(url, config, **params)
 
     @staticmethod
     def get_tiling_grid(grid_id, config=None):
@@ -176,7 +178,8 @@ class SentinelHubBatch:
         :rtype: dict
         """
         url = f'{SentinelHubBatch._get_tiling_grids_url(config)}/{grid_id}'
-        return get_auth_json(url)
+        client = SentinelHubDownloadClient(config=config)
+        return client.get_json(url, use_session=True)
 
     @property
     def info(self):
@@ -196,7 +199,8 @@ class SentinelHubBatch:
         :rtype: dict
         """
         url = self._get_process_url(self.config, request_id=self.request_id)
-        self._request_info = get_auth_json(url)
+        client = SentinelHubDownloadClient(config=self.config)
+        self._request_info = client.get_json(url, use_session=True)
 
     @property
     def evalscript(self):
@@ -252,7 +256,7 @@ class SentinelHubBatch:
             'userid': user_id,
             **kwargs
         })
-        for request_info in _iter_pages(url, **params):
+        for request_info in _iter_pages(url, config, **params):
             yield SentinelHubBatch(request_info=request_info, config=config)
 
     @staticmethod
@@ -267,7 +271,8 @@ class SentinelHubBatch:
         """ Delete a batch job request
         """
         url = self._get_process_url(self.config, request_id=self.request_id)
-        return get_auth_json(url, request_type=RequestType.DELETE)
+        client = SentinelHubDownloadClient(config=self.config)
+        return client.get_json(url, request_type=RequestType.DELETE, use_session=True)
 
     def start_analysis(self):
         """ Starts analysis of a batch job request
@@ -303,7 +308,7 @@ class SentinelHubBatch:
             'status': status,
             **kwargs
         })
-        return _iter_pages(url, **params)
+        return _iter_pages(url, self.config, **params)
 
     def get_tile(self, tile_id):
         """ Provides information about a single batch request tile
@@ -314,7 +319,8 @@ class SentinelHubBatch:
         :rtype: dict
         """
         url = self._get_tiles_url(tile_id=tile_id)
-        return get_auth_json(url)
+        client = SentinelHubDownloadClient(config=self.config)
+        return client.get_json(url, use_session=True)
 
     def reprocess_tile(self, tile_id):
         """ Reprocess a single failed tile
@@ -338,7 +344,9 @@ class SentinelHubBatch:
         """
         process_url = self._get_process_url(request_id=self.request_id, config=self.config)
         url = f'{process_url}/{endpoint_name}'
-        return get_auth_json(url, request_type=RequestType.POST)
+
+        client = SentinelHubDownloadClient(config=self.config)
+        return client.get_json(url, request_type=RequestType.POST, use_session=True)
 
     def _get_tiles_url(self, tile_id=None):
         """ Creates an URL for tiles endpoint
@@ -378,17 +386,18 @@ def _remove_undefined_params(payload):
     return {name: value for name, value in payload.items() if value is not None}
 
 
-def _iter_pages(service_url, **params):
+def _iter_pages(service_url, config, **params):
     """ Iterates over pages of items
     """
     token = None
+    client = SentinelHubDownloadClient(config=config)
 
     while True:
         if token is not None:
             params['viewtoken'] = token
 
         url = f'{service_url}?{urlencode(params)}'
-        results = get_auth_json(url)
+        results = client.get_json(url, use_session=True)
 
         for item in results['member']:
             yield item


### PR DESCRIPTION
The following enables that `get_json` and `get_xml` helpers can be used by classes that inherit from `DownloadClient` without a need for another helper function.