### PR TITLE
add floats to config allowed parameters

### DIFF
--- a/sentinelhub/config.py
+++ b/sentinelhub/config.py
@@ -4,6 +4,7 @@ Module for managing configuration data from `config.json`
 
 import os
 import json
+import numbers
 
 
 class SHConfig:
@@ -57,8 +58,8 @@ class SHConfig:
             'max_wfs_records_per_query': 100,
             'max_opensearch_records_per_query': 500,
             'max_download_attempts': 4,
-            'download_sleep_time': 5,
-            'download_timeout_seconds': 120,
+            'download_sleep_time': 5.0,
+            'download_timeout_seconds': 120.0,
             'number_of_download_processes': 1
         }
 
@@ -75,7 +76,9 @@ class SHConfig:
 
             for param, default_param in self.CONFIG_PARAMS.items():
                 param_type = type(default_param)
-                if not isinstance(config[param], param_type):
+                if (param_type is float) and isinstance(config[param], numbers.Number):
+                    continue
+                elif not isinstance(config[param], param_type):
                     raise ValueError("Value of parameter '{}' must be of type {}".format(param, param_type.__name__))
 
             if config['max_wfs_records_per_query'] > 100:

--- a/sentinelhub/config.py
+++ b/sentinelhub/config.py
@@ -78,7 +78,7 @@ class SHConfig:
                 param_type = type(default_param)
                 if (param_type is float) and isinstance(config[param], numbers.Number):
                     continue
-                elif not isinstance(config[param], param_type):
+                if not isinstance(config[param], param_type):
                     raise ValueError("Value of parameter '{}' must be of type {}".format(param, param_type.__name__))
 
             if config['max_wfs_records_per_query'] > 100:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -43,6 +43,18 @@ class TestSHConfig(TestSentinelHub):
         self.assertEqual(config.instance_id, config._instance.CONFIG_PARAMS['instance_id'],
                          'Instance ID should reset')
 
+    def test_save(self):
+        config = SHConfig()
+        old_value = config.download_timeout_seconds
+        config.download_timeout_seconds = "abcd"
+        self.assertRaises(ValueError, config.save)
+        new_value = 150.5
+        config.download_timeout_seconds = new_value
+        config.save()
+        config = SHConfig()
+        self.assertEqual(config.download_timeout_seconds, new_value, "Saved value has not changed")
+        config.download_timeout_seconds = old_value
+        config.save()
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
`download_timeout_seconds` and `download_sleep_time` can now be float or int type, instead of only int.