### PR TITLE
use parsing function when retriving type

### DIFF
--- a/sentinelhub/sentinelhub_request.py
+++ b/sentinelhub/sentinelhub_request.py
@@ -43,7 +43,8 @@ class SentinelHubRequest(DataRequest):
         if not isinstance(evalscript, str):
             raise ValueError("'evalscript' should be a string")
 
-        self.mime_type = MimeType.TAR if len(responses) > 1 else MimeType(responses[0]['format']['type'].split('/')[1])
+        parsed_mime_type = MimeType.from_string(responses[0]['format']['type'].split('/')[1])
+        self.mime_type = MimeType.TAR if len(responses) > 1 else parsed_mime_type
 
         self.payload = self.body(
             request_bounds=self.bounds(bbox=bbox, geometry=geometry),

--- a/tests/test_sentinelhub_request.py
+++ b/tests/test_sentinelhub_request.py
@@ -16,7 +16,7 @@ class TestSentinelHubRequest(TestSentinelHub):
     """ Tests for the Processing API requests
     """
 
-    def test_single_tiff(self):
+    def test_single_jpg(self):
         """ Test downloading three bands of L1C
         """
         evalscript = """
@@ -29,8 +29,7 @@ class TestSentinelHubRequest(TestSentinelHub):
                         units: "REFLECTANCE"
                     }],
                     output: {
-                        bands: 3,
-                        sampleType: "FLOAT32"
+                        bands: 3
                     }
                 };
             }
@@ -50,7 +49,7 @@ class TestSentinelHubRequest(TestSentinelHub):
                 )
             ],
             responses=[
-                SentinelHubRequest.output_response('default', MimeType.TIFF)
+                SentinelHubRequest.output_response('default', MimeType.JPG)
             ],
             bbox=BBox(bbox=[46.16, -16.15, 46.51, -15.58], crs=CRS.WGS84),
             size=(512, 856)
@@ -59,7 +58,7 @@ class TestSentinelHubRequest(TestSentinelHub):
         img = request.get_data(max_threads=3)[0]
 
         self.assertEqual(img.shape, (856, 512, 3))
-        self.test_numpy_data(img, exp_min=0, exp_max=2.01825, exp_mean=0.29408056)
+        self.test_numpy_data(img, exp_min=0, exp_max=255, exp_mean=74.898)
 
     def test_other_args(self):
         """ Test downloading three bands of L1C


### PR DESCRIPTION
MimeType has an already implemented function to parse types, the function implement the logic to deal with parsing of  "jpeg"  and "jpg" file formats.