### PR TITLE
Open time intervals and "cloudy" collections

### DIFF
--- a/sentinelhub/constants.py
+++ b/sentinelhub/constants.py
@@ -292,7 +292,7 @@ class HistogramType(Enum):
 
 
 class MimeType(Enum):
-    """ Enum class to represent supported image file formats
+    """ Enum class to represent supported file formats
 
     Supported file formats are TIFF 8-bit, TIFF 16-bit, TIFF 32-bit float, PNG, JPEG, JPEG2000, JSON, CSV, ZIP, HDF5,
     XML, GML, RAW

--- a/sentinelhub/data_collections.py
+++ b/sentinelhub/data_collections.py
@@ -152,6 +152,7 @@ class DataCollectionDefinition:
     bands: Tuple[str, ...] = None
     collection_id: str = None
     is_timeless: bool = False
+    has_cloud_coverage: bool = False
 
     def __post_init__(self):
         """ In case a list of bands has been given this makes sure to cast it into a tuple
@@ -195,7 +196,8 @@ class DataCollection(Enum, metaclass=_DataCollectionMeta):
         collection_type=_CollectionType.SENTINEL2,
         sensor_type=_SensorType.MSI,
         processing_level=_ProcessingLevel.L1C,
-        bands=_Bands.SENTINEL2_L1C
+        bands=_Bands.SENTINEL2_L1C,
+        has_cloud_coverage=True
     )
     SENTINEL2_L2A = DataCollectionDefinition(
         api_id='S2L2A',
@@ -204,7 +206,8 @@ class DataCollection(Enum, metaclass=_DataCollectionMeta):
         collection_type=_CollectionType.SENTINEL2,
         sensor_type=_SensorType.MSI,
         processing_level=_ProcessingLevel.L2A,
-        bands=_Bands.SENTINEL2_L2A
+        bands=_Bands.SENTINEL2_L2A,
+        has_cloud_coverage=True
     )
 
     SENTINEL1 = DataCollectionDefinition(
@@ -273,7 +276,8 @@ class DataCollection(Enum, metaclass=_DataCollectionMeta):
         service_url=ServiceUrl.USWEST,
         collection_type=_CollectionType.LANDSAT8,
         processing_level=_ProcessingLevel.L1C,
-        bands=_Bands.LANDSAT8
+        bands=_Bands.LANDSAT8,
+        has_cloud_coverage=True
     )
 
     SENTINEL5P = DataCollectionDefinition(
@@ -304,7 +308,8 @@ class DataCollection(Enum, metaclass=_DataCollectionMeta):
         collection_type=_CollectionType.SENTINEL3,
         sensor_type=_SensorType.SLSTR,
         processing_level=_ProcessingLevel.L1B,
-        bands=_Bands.SENTINEL3_SLSTR
+        bands=_Bands.SENTINEL3_SLSTR,
+        has_cloud_coverage=True
     )
 
     # EOCloud collections (which are only available on a development eocloud service):

--- a/sentinelhub/data_collections.py
+++ b/sentinelhub/data_collections.py
@@ -137,6 +137,7 @@ class DataCollectionDefinition:
 
     Check `DataCollection.define` for more info about attributes of this class
     """
+    # pylint: disable=too-many-instance-attributes
     api_id: str = None
     catalog_id: str = None
     wfs_id: str = None

--- a/sentinelhub/sentinelhub_catalog.py
+++ b/sentinelhub/sentinelhub_catalog.py
@@ -130,7 +130,7 @@ class SentinelHubCatalog:
         url = f'{self.catalog_url}/search'
 
         collection_id = self._parse_collection_id(collection)
-        start_time, end_time = serialize_time(parse_time_interval(time), use_tz=True)
+        start_time, end_time = serialize_time(parse_time_interval(time, allow_undefined=True), use_tz=True)
 
         if bbox and bbox.crs is not CRS.WGS84:
             bbox = bbox.transform_bounds(CRS.WGS84)

--- a/sentinelhub/sentinelhub_request.py
+++ b/sentinelhub/sentinelhub_request.py
@@ -286,7 +286,7 @@ def _get_data_filters(data_collection, time_interval, maxcc, mosaicking_order):
     data_filter = {}
 
     if time_interval:
-        start_time, end_time = serialize_time(parse_time_interval(time_interval), use_tz=True)
+        start_time, end_time = serialize_time(parse_time_interval(time_interval, allow_undefined=True), use_tz=True)
         data_filter['timeRange'] = {'from': start_time, 'to': end_time}
 
     if maxcc is not None:

--- a/tests/test_time_utils.py
+++ b/tests/test_time_utils.py
@@ -9,7 +9,6 @@ import dateutil.tz
 from sentinelhub import time_utils
 
 
-TEST_NONE_DATE = None
 TEST_DATE = dt.date(year=2015, month=4, day=12)
 TEST_DATETIME = dt.datetime(year=2015, month=4, day=12, hour=12, minute=32, second=14)
 TEST_DATETIME_TZ = dt.datetime(year=2015, month=4, day=12, hour=12, minute=32, second=14, tzinfo=dateutil.tz.tzutc())
@@ -71,10 +70,10 @@ def test_parse_time(time_input, params, expected_output):
     (('2015.4.12T12:32:14', '2017.4.12T12:32:14'), {}, (TEST_DATETIME, TEST_DATETIME.replace(year=2017))),
     ((TEST_DATE, TEST_DATE.replace(year=2017)), {}, (TEST_TIME_START, TEST_TIME_END.replace(year=2017))),
     ((TEST_DATETIME, TEST_DATETIME.replace(year=2017)), {}, (TEST_DATETIME, TEST_DATETIME.replace(year=2017))),
-    (None, {'allow_undefined': True}, '..'),
-    ((None, None), {'allow_undefined': True}, ('..', '..')),
-    ((None, TEST_DATE), {'allow_undefined': True}, ('..', TEST_DATE)),
-    ((TEST_DATE, None), {'allow_undefined': True}, (TEST_DATE, '..')),
+    (None, {'allow_undefined': True}, (None, None)),
+    ((None, None), {'allow_undefined': True}, (None, None)),
+    ((TEST_DATETIME, None), {'allow_undefined': True}, (TEST_DATETIME, None)),
+    ((None, TEST_DATE), {'allow_undefined': True}, (None, TEST_TIME_END)),
 ])
 def test_parse_time_interval(time_input, params, expected_output):
     parsed_interval = time_utils.parse_time_interval(time_input, **params)
@@ -82,28 +81,20 @@ def test_parse_time_interval(time_input, params, expected_output):
 
 
 @pytest.mark.parametrize('time_input,params,expected_output', [
-    (TEST_NONE_DATE, {'allow_undefined': True}, '..'),
+    (None, {}, '..'),
     (TEST_DATE, {}, '2015-04-12'),
     (TEST_DATETIME, {}, '2015-04-12T12:32:14'),
     (TEST_DATETIME, {'use_tz': True}, '2015-04-12T12:32:14Z'),
     (TEST_DATETIME_TZ, {'use_tz': False}, '2015-04-12T12:32:14'),
     (TEST_DATETIME_TZ, {'use_tz': True}, '2015-04-12T12:32:14Z'),
-    ((TEST_DATE, TEST_DATETIME, TEST_DATETIME_TZ), {}, ('2015-04-12', '2015-04-12T12:32:14', '2015-04-12T12:32:14'))
+    ((TEST_DATE, TEST_DATETIME, TEST_DATETIME_TZ), {}, ('2015-04-12', '2015-04-12T12:32:14', '2015-04-12T12:32:14')),
+    ((None, None), {}, ('..', '..')),
+    ((TEST_DATETIME, None), {}, ('2015-04-12T12:32:14', '..')),
+    ((None, TEST_DATETIME), {}, ('..', '2015-04-12T12:32:14'))
 ])
-def test_parse_time_interval(time_input, params, expected_output):
+def test_serialize_time(time_input, params, expected_output):
     serialized_result = time_utils.serialize_time(time_input, **params)
     assert serialized_result == expected_output
-
-
-@pytest.mark.parametrize('non_allowed_time_input', [
-    None,
-    (None, None),
-    (dt.datetime.now(), None),
-    (None, dt.datetime.now())
-])
-def test_empty_time_not_allowed(non_allowed_time_input):
-    with pytest.raises(ValueError):
-        time_utils.serialize_time(non_allowed_time_input)
 
 
 @pytest.mark.parametrize('input_date,input_time,expected_output', [


### PR DESCRIPTION
This PR tweaks the time (interval) parsing in order to allow open-ended interval requests to (some) SH services. Additionally, it adds `has_cloud_coverage(=False)` flag to DataCollections and sets it to true to collections that have CC as queryable parameter. 