### PR TITLE
Minor documentation improvements

### DIFF
--- a/docs/source/areas.rst
+++ b/docs/source/areas.rst
@@ -14,3 +14,9 @@ Module for working with large geographical areas
     :members:
 .. autoclass:: CustomGridSplitter
     :members:
+.. autoclass:: UtmGridSplitter
+    :members:
+.. autoclass:: UtmZoneSplitter
+    :members:
+.. autoclass:: BatchSplitter
+    :members:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -213,7 +213,7 @@ epub_copyright = project_copyright
 epub_exclude_files = ['search.html']
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'https://docs.python.org/3.6/': None}
+intersphinx_mapping = {'https://docs.python.org/3.8/': None}
 
 # copy examples
 try:

--- a/docs/source/docs.rst
+++ b/docs/source/docs.rst
@@ -33,6 +33,6 @@ Modules
     sentinelhub_rate_limit
     sentinelhub_request
     sentinelhub_session
+    sh_utils
     testing_utils
     time_utils
-    sh_utils

--- a/docs/source/fis.rst
+++ b/docs/source/fis.rst
@@ -1,5 +1,5 @@
 fis
-======
+===
 
 .. automodule:: sentinelhub.fis
     :members:

--- a/docs/source/sentinelhub_byoc.rst
+++ b/docs/source/sentinelhub_byoc.rst
@@ -1,5 +1,5 @@
 sentinelhub_byoc
-===================
+================
 
 .. automodule:: sentinelhub.sentinelhub_byoc
     :members:

--- a/sentinelhub/config.py
+++ b/sentinelhub/config.py
@@ -17,7 +17,7 @@ class SHConfig:
         - `sh_client_id`: User's OAuth client ID for Sentinel Hub service
         - `sh_client_secret`: User's OAuth client secret for Sentinel Hub service
         - `sh_base_url`: There exist multiple deployed instances of Sentinel Hub service, this parameter defines the
-            location of a specific service instance.
+          location of a specific service instance.
         - `geopedia_wms_url`: Base url for Geopedia WMS services.
         - `geopedia_rest_url`: Base url for Geopedia REST services.
         - `aws_access_key_id`: Access key for AWS Requester Pays buckets.

--- a/sentinelhub/download/client.py
+++ b/sentinelhub/download/client.py
@@ -25,10 +25,11 @@ class DownloadClient:
     """ A basic download client object
 
     It does the following:
-      - downloads the data with multiple threads in parallel,
-      - handles any exceptions that occur during download,
-      - decodes downloaded data,
-      - reads and writes locally stored/cached data
+
+    - downloads the data with multiple threads in parallel,
+    - handles any exceptions that occur during download,
+    - decodes downloaded data,
+    - reads and writes locally stored/cached data
     """
     def __init__(self, *, redownload=False, raise_download_errors=True, config=None):
         """

--- a/sentinelhub/geometry.py
+++ b/sentinelhub/geometry.py
@@ -101,9 +101,10 @@ class BBox(BaseGeometry):
         9) ``bbox``, where ``bbox`` is an instance of ``BBox``.
 
     Note that BBox coordinate system depends on ``crs`` parameter:
-        - In case of ``constants.CRS.WGS84`` axis x represents longitude and axis y represents latitude
-        - In case of ``constants.CRS.POP_WEB`` axis x represents easting and axis y represents northing
-        - In case of ``constants.CRS.UTM_*`` axis x represents easting and axis y represents northing
+
+    - In case of ``constants.CRS.WGS84`` axis x represents longitude and axis y represents latitude
+    - In case of ``constants.CRS.POP_WEB`` axis x represents easting and axis y represents northing
+    - In case of ``constants.CRS.UTM_*`` axis x represents easting and axis y represents northing
     """
     def __init__(self, bbox, crs):
         """

--- a/sentinelhub/sentinelhub_rate_limit.py
+++ b/sentinelhub/sentinelhub_rate_limit.py
@@ -10,8 +10,9 @@ class SentinelHubRateLimit:
     """ Class implementing rate limiting logic of Sentinel Hub service
 
     It has 2 public methods:
-     - register_next - tells if next download can start or if not, what is the wait before it can be asked again
-     - update - updates expectations according to headers obtained from download
+
+    - register_next - tells if next download can start or if not, what is the wait before it can be asked again
+    - update - updates expectations according to headers obtained from download
 
     The rate limiting object is collecting information about the status of rate limiting policy buckets from
     Sentinel Hub service. According to this information and a feedback from download requests it adapts expectations

--- a/sentinelhub/sh_utils.py
+++ b/sentinelhub/sh_utils.py
@@ -11,9 +11,10 @@ class FeatureIterator(ABC):
     """ An implementation of a base feature iteration class
 
     Main functionalities:
+
     - The iterator will load only as many features as needed at any moment
     - It will keep downloaded features in memory so that iterating over it again will not have to download the same
-    features again.
+      features again.
     """
     def __init__(self, client, url, params=None):
         """


### PR DESCRIPTION
I went through documentation pages and fixed various minor issues.

I did this mainly to try fixing a weird documentation issue where `automodule` functionality cannot be used in `areas.rst` file. If I try using it then the content of all module documentation pages suddenly disappears in the built documentation. I tried various things but still couldn't figure it out.