### PR TITLE
DataCollection transfer fix

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,4 +4,3 @@ codecov
 pylint>=2.2.0
 twine
 requests-mock
-ray[default]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,3 +4,4 @@ codecov
 pylint>=2.2.0
 twine
 requests-mock
+ray[default]

--- a/sentinelhub/aws.py
+++ b/sentinelhub/aws.py
@@ -226,7 +226,7 @@ class AwsService(ABC):
             if not isinstance(substruct, dict):
                 product_name, data_name = self._url_to_props(substruct)
                 if '.' in data_name:
-                    data_type = MimeType(data_name.split('.')[-1])
+                    data_type = MimeType(data_name.split('.', 1)[-1])
                     data_name = data_name.rsplit('.', 1)[0]
                 else:
                     data_type = MimeType.RAW

--- a/tests/test_data_collections.py
+++ b/tests/test_data_collections.py
@@ -3,7 +3,7 @@ Unit tests for data_collections module
 """
 import unittest
 
-import ray
+import pytest
 
 from sentinelhub import DataCollection, TestSentinelHub, SHConfig
 from sentinelhub.constants import ServiceUrl
@@ -142,6 +142,7 @@ def test_data_collection_transfer_with_ray():
     """ This tests makes sure that the process of transferring a custom DataCollection object to a Ray worker and back
     works correctly.
     """
+    ray = pytest.importorskip('ray')
     ray.init(log_to_driver=False)
 
     collection = DataCollection.SENTINEL2_L1C.define_from('MY_NEW_COLLECTION', api_id='xxx')


### PR DESCRIPTION
This solves the problem with the following procedure:

- define a custom `DataCollection` enum,
- pass the new enum to another process (by `pickle` serialization),
- deserialize the enum in the new process.

This enables that this object is used with Ray framework.