### PR TITLE
Updated Sphinx docs to show inherited members of classes

### DIFF
--- a/docs/source/areas.rst
+++ b/docs/source/areas.rst
@@ -8,15 +8,22 @@ Module for working with large geographical areas
     :members:
 .. autoclass:: BBoxSplitter
     :members:
+    :inherited-members:
 .. autoclass:: OsmSplitter
     :members:
+    :inherited-members:
 .. autoclass:: TileSplitter
     :members:
+    :inherited-members:
 .. autoclass:: CustomGridSplitter
     :members:
+    :inherited-members:
 .. autoclass:: UtmGridSplitter
     :members:
+    :inherited-members:
 .. autoclass:: UtmZoneSplitter
     :members:
+    :inherited-members:
 .. autoclass:: BatchSplitter
     :members:
+    :inherited-members:

--- a/docs/source/data_collections.rst
+++ b/docs/source/data_collections.rst
@@ -3,4 +3,5 @@ data_collections
 
 .. automodule:: sentinelhub.data_collections
     :members:
+    :inherited-members:
     :show-inheritance:

--- a/docs/source/data_request.rst
+++ b/docs/source/data_request.rst
@@ -3,4 +3,5 @@ data_request
 
 .. automodule:: sentinelhub.data_request
     :members:
+    :inherited-members:
     :show-inheritance:

--- a/docs/source/download.aws_client.rst
+++ b/docs/source/download.aws_client.rst
@@ -3,4 +3,5 @@ download.aws_client
 
 .. automodule:: sentinelhub.download.aws_client
     :members:
+    :inherited-members:
     :show-inheritance:

--- a/docs/source/download.sentinelhub_client.rst
+++ b/docs/source/download.sentinelhub_client.rst
@@ -3,4 +3,5 @@ download.sentinelhub_client
 
 .. automodule:: sentinelhub.download.sentinelhub_client
     :members:
+    :inherited-members:
     :show-inheritance:

--- a/docs/source/download.sentinelhub_statistical_client.rst
+++ b/docs/source/download.sentinelhub_statistical_client.rst
@@ -3,4 +3,5 @@ download.sentinelhub_statistical_client
 
 .. automodule:: sentinelhub.download.sentinelhub_statistical_client
     :members:
+    :inherited-members:
     :show-inheritance:

--- a/docs/source/geometry.rst
+++ b/docs/source/geometry.rst
@@ -3,4 +3,5 @@ geometry
 
 .. automodule:: sentinelhub.geometry
     :members:
+    :inherited-members:
     :show-inheritance:

--- a/docs/source/geopedia.rst
+++ b/docs/source/geopedia.rst
@@ -3,4 +3,5 @@ geopedia
 
 .. automodule:: sentinelhub.geopedia
     :members:
+    :inherited-members:
     :show-inheritance:

--- a/docs/source/ogc.rst
+++ b/docs/source/ogc.rst
@@ -3,4 +3,5 @@ ogc
 
 .. automodule:: sentinelhub.ogc
     :members:
+    :inherited-members:
     :show-inheritance:

--- a/docs/source/sentinelhub_batch.rst
+++ b/docs/source/sentinelhub_batch.rst
@@ -3,4 +3,5 @@ sentinelhub_batch
 
 .. automodule:: sentinelhub.sentinelhub_batch
     :members:
+    :inherited-members:
     :show-inheritance:

--- a/docs/source/sentinelhub_byoc.rst
+++ b/docs/source/sentinelhub_byoc.rst
@@ -3,4 +3,5 @@ sentinelhub_byoc
 
 .. automodule:: sentinelhub.sentinelhub_byoc
     :members:
+    :inherited-members:
     :show-inheritance:

--- a/docs/source/sentinelhub_catalog.rst
+++ b/docs/source/sentinelhub_catalog.rst
@@ -3,4 +3,5 @@ sentinelhub_catalog
 
 .. automodule:: sentinelhub.sentinelhub_catalog
     :members:
+    :inherited-members:
     :show-inheritance:

--- a/docs/source/sentinelhub_rate_limit.rst
+++ b/docs/source/sentinelhub_rate_limit.rst
@@ -3,4 +3,5 @@ sentinelhub_rate_limit
 
 .. automodule:: sentinelhub.sentinelhub_rate_limit
     :members:
+    :inherited-members:
     :show-inheritance:

--- a/docs/source/sentinelhub_request.rst
+++ b/docs/source/sentinelhub_request.rst
@@ -3,4 +3,5 @@ sentinelhub_request
 
 .. automodule:: sentinelhub.sentinelhub_request
     :members:
+    :inherited-members:
     :show-inheritance:

--- a/docs/source/sentinelhub_session.rst
+++ b/docs/source/sentinelhub_session.rst
@@ -3,4 +3,5 @@ sentinelhub_session
 
 .. automodule:: sentinelhub.sentinelhub_session
     :members:
+    :inherited-members:
     :show-inheritance:

--- a/docs/source/sentinelhub_statistical.rst
+++ b/docs/source/sentinelhub_statistical.rst
@@ -3,4 +3,5 @@ sentinelhub_statistical
 
 .. automodule:: sentinelhub.sentinelhub_statistical
     :members:
+    :inherited-members:
     :show-inheritance:

--- a/docs/source/sh_utils.rst
+++ b/docs/source/sh_utils.rst
@@ -3,4 +3,5 @@ sh_utils
 
 .. automodule:: sentinelhub.sh_utils
     :members:
+    :inherited-members:
     :show-inheritance:


### PR DESCRIPTION
By adding `:inherited-members:` tag into docs classes will now also show methods that they inherited from their parent classes.