### PR TITLE
An option to hide config credentials

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,71 +1,109 @@
-import unittest
+"""
+Unit tests for config.py module
+"""
 import json
 import os
 
-from sentinelhub import SHConfig, TestSentinelHub
+import pytest
+
+from sentinelhub import SHConfig
 
 
-class TestSHConfig(TestSentinelHub):
-    def test_configuration(self):
-        SHConfig().save()
+def test_config_file():
+    config = SHConfig()
 
-        config_file = SHConfig().get_config_location()
+    config_file = config.get_config_location()
+    assert os.path.isfile(config_file), f'Config file does not exist: {os.path.abspath(config_file)}'
 
-        if not os.path.isfile(config_file):
-            self.fail(msg='Config file does not exist: {}'.format(os.path.abspath(config_file)))
+    with open(config_file, 'r') as fp:
+        config_dict = json.load(fp)
 
-        with open(config_file, 'r') as fp:
-            config = json.load(fp)
+    for param, value in config_dict.items():
+        if param in config._instance.CREDENTIALS:
+            continue
 
-        for attr in config:
-            if attr not in ['instance_id', 'aws_access_key_id', 'aws_secret_access_key',
-                            'sh_client_id', 'sh_client_secret']:
-                value = config[attr]
-                if isinstance(value, str):
-                    value = value.rstrip('/')
-                self.assertEqual(SHConfig()[attr], value,
-                                 "Expected value {}, got {}".format(config[attr], SHConfig()[attr]))
+        if isinstance(value, str):
+            value = value.rstrip('/')
 
-    def test_reset(self):
-        config = SHConfig()
+        assert config[param] == value
 
-        old_value = config.instance_id
-        new_value = 'new'
-        config.instance_id = new_value
-        self.assertEqual(config.instance_id, new_value, 'New value was not set')
-        self.assertEqual(config['instance_id'], new_value, 'New value was not set')
-        self.assertEqual(config._instance.instance_id, old_value, 'Private value has changed')
 
-        config.reset('sh_base_url')
-        config.reset(['aws_access_key_id', 'aws_secret_access_key'])
-        self.assertEqual(config.instance_id, new_value, 'Instance ID should not reset yet')
-        config.reset()
-        self.assertEqual(config.instance_id, config._instance.CONFIG_PARAMS['instance_id'],
-                         'Instance ID should reset')
+def test_reset():
+    config = SHConfig()
 
-    def test_save(self):
-        config = SHConfig()
-        old_value = config.download_timeout_seconds
-        config.download_timeout_seconds = "abcd"
-        self.assertRaises(ValueError, config.save)
-        new_value = 150.5
-        config.download_timeout_seconds = new_value
-        config.save()
-        config = SHConfig()
-        self.assertEqual(config.download_timeout_seconds, new_value, "Saved value has not changed")
-        config.download_timeout_seconds = old_value
+    old_value = config.instance_id
+    new_value = 'new'
+    config.instance_id = new_value
+    assert config.instance_id == new_value, 'New value was not set'
+    assert config['instance_id'] == new_value, 'New value was not set'
+    assert config._instance.instance_id == old_value, 'Private value has changed'
+
+    config.reset('sh_base_url')
+    config.reset(['aws_access_key_id', 'aws_secret_access_key'])
+    assert config.instance_id == new_value, 'Instance ID should not reset yet'
+
+    config.reset()
+    assert config.instance_id == config._instance.CONFIG_PARAMS['instance_id'], 'Instance ID should reset'
+
+
+def test_save():
+    config = SHConfig()
+    old_value = config.download_timeout_seconds
+
+    config.download_timeout_seconds = 'abcd'
+    with pytest.raises(ValueError):
         config.save()
 
-    def test_raise_for_missing_instance_id(self):
-        config = SHConfig()
+    new_value = 150.5
+    config.download_timeout_seconds = new_value
+    config.save()
+    config = SHConfig()
+    assert config.download_timeout_seconds == new_value, 'Saved value should have changed'
 
-        config.instance_id = 'xxx'
+    config.download_timeout_seconds = old_value
+    config.save()
+
+
+def test_raise_for_missing_instance_id():
+    config = SHConfig()
+
+    config.instance_id = 'xxx'
+    config.raise_for_missing_instance_id()
+
+    config.instance_id = ''
+    with pytest.raises(ValueError):
         config.raise_for_missing_instance_id()
 
-        config.instance_id = ''
-        with self.assertRaises(ValueError):
-            config.raise_for_missing_instance_id()
+
+@pytest.mark.parametrize('hide_credentials', [False, True])
+def test_config_repr(hide_credentials):
+    config = SHConfig(hide_credentials=hide_credentials)
+    config.instance_id = 'a' * 20
+    config_repr = repr(config)
+
+    assert config_repr.startswith(SHConfig.__name__)
+
+    if hide_credentials:
+        assert config.instance_id not in config_repr
+        assert '*' * 16 + 'a' * 4 in config_repr
+    else:
+        for param in config.get_params():
+            assert f'{param}={repr(config[param])}' in config_repr
 
 
-if __name__ == '__main__':
-    unittest.main()
+@pytest.mark.parametrize('hide_credentials', [False, True])
+def test_get_config_dict(hide_credentials):
+    config = SHConfig(hide_credentials=hide_credentials)
+    config.sh_client_secret = 'x' * 15
+    config.aws_secret_access_key = 'y' * 10
+
+    config_dict = config.get_config_dict()
+    assert isinstance(config_dict, dict)
+    assert list(config_dict) == config.get_params()
+
+    if hide_credentials:
+        assert config_dict['sh_client_secret'] == '*' * 11 + 'x' * 4
+        assert config_dict['aws_secret_access_key'] == '*' * 10
+    else:
+        assert config_dict['sh_client_secret'] == config.sh_client_secret
+        assert config_dict['aws_secret_access_key'] == config.aws_secret_access_key

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -9,6 +9,16 @@ import pytest
 from sentinelhub import SHConfig
 
 
+@pytest.fixture(name='restore_config')
+def restore_config_fixture():
+    """ A fixture that makes sure original config is restored after a test is executed. It restores the config even if
+    a test has failed.
+    """
+    original_config = SHConfig()
+    yield
+    original_config.save()
+
+
 def test_config_file():
     config = SHConfig()
 
@@ -46,9 +56,8 @@ def test_reset():
     assert config.instance_id == config._instance.CONFIG_PARAMS['instance_id'], 'Instance ID should reset'
 
 
-def test_save():
+def test_save(restore_config):
     config = SHConfig()
-    old_value = config.download_timeout_seconds
 
     config.download_timeout_seconds = 'abcd'
     with pytest.raises(ValueError):
@@ -59,9 +68,6 @@ def test_save():
     config.save()
     config = SHConfig()
     assert config.download_timeout_seconds == new_value, 'Saved value should have changed'
-
-    config.download_timeout_seconds = old_value
-    config.save()
 
 
 def test_raise_for_missing_instance_id():


### PR DESCRIPTION
Instances of `SHConfig` are usually passed around in the code a lot, which means that some frameworks, such as eo-learn, would log it and write into a report. But the problem is that a representation of a config object reveals all its parameters, including its credentials.

This PR adds an option to hide credentials. It also refactors unit tests for `SHConfig` and adds a few new ones.