### PR TITLE
missing single quote on sentinel-hub-configuration readthedocs page

### DIFF
--- a/docs/source/configure.rst
+++ b/docs/source/configure.rst
@@ -59,7 +59,7 @@ or set them up by configuring an instance of :class:`~sentinelhub.config.SHConfi
 
     config = SHConfig()
 
-    config.instance_id = '<your instance id>
+    config.instance_id = '<your instance id>'
     config.sh_client_id = '<your client id>'
     config.sh_client_secret = '<your client secret>'
 


### PR DESCRIPTION
Missing single quote inside of tutorial code block on line 62. 
Noticed this while running through the configuration directions and it triggered my OCD, lol.