### PR TITLE
Fix false cache collision detections

### DIFF
--- a/sentinelhub/download/client.py
+++ b/sentinelhub/download/client.py
@@ -5,6 +5,7 @@ import logging
 import warnings
 import os
 import sys
+import json
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 import requests
@@ -169,8 +170,10 @@ class DownloadClient:
         # Timestamps are allowed to differ
         del cached_request_info['timestamp']
         del cached_request_info['headers']
+        # Saved request was jsonified
+        current_request_info_json = json.loads(json.dumps(current_request_info))
 
-        if cached_request_info != current_request_info:
+        if cached_request_info != current_request_info_json:
             raise HashedNameCollisionException(
                 f'Request has hashed name {request.get_hashed_name()}, which matches request saved at {request_path}, '
                 f'but the requests are different. Possible hash collision'

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -6,7 +6,7 @@ import os
 
 import pytest
 
-from sentinelhub import DownloadRequest, MimeType, DownloadClient
+from sentinelhub import DownloadRequest, MimeType, DownloadClient, write_data
 from sentinelhub.exceptions import SHRuntimeWarning, HashedNameCollisionException
 
 
@@ -115,3 +115,14 @@ def test_hash_collision(download_request):
 
     with pytest.raises(HashedNameCollisionException):
         client.download(request3)
+
+    # Check that there are no issues with re-loading
+    request4 = copy.deepcopy(download_request)
+    request4.post_values = {'transformed-when-saved': [(1, 2)]}
+
+    request_path, _ = request4.get_storage_paths()
+    request_info = request4.get_request_params(include_metadata=True)
+    write_data(request_path, request_info, data_format=MimeType.JSON)  # Copied from download client
+
+    # pylint: disable=protected-access
+    client._check_cached_request_is_matching(request4, request_path)


### PR DESCRIPTION
In cases where a request contains an object that changes types during json serialization the hash collision would consider the cached request as different and falsely raise an error