### PR TITLE
Support AWS session tokens

### DIFF
--- a/sentinelhub/config.py
+++ b/sentinelhub/config.py
@@ -56,6 +56,7 @@ class SHConfig:
             'geopedia_rest_url': 'https://www.geopedia.world/rest',
             'aws_access_key_id': '',
             'aws_secret_access_key': '',
+            'aws_session_token': '',
             'aws_metadata_url': 'https://roda.sentinel-hub.com',
             'aws_s3_l1c_bucket': 'sentinel-s2-l1c',
             'aws_s3_l2a_bucket': 'sentinel-s2-l2a',
@@ -72,7 +73,8 @@ class SHConfig:
             'sh_client_id',
             'sh_client_secret',
             'aws_access_key_id',
-            'aws_secret_access_key'
+            'aws_secret_access_key',
+            'aws_session_token'
         }
 
         def __init__(self):

--- a/sentinelhub/download/aws_client.py
+++ b/sentinelhub/download/aws_client.py
@@ -42,7 +42,8 @@ class AwsDownloadClient(DownloadClient):
         if self.config.aws_access_key_id and self.config.aws_secret_access_key:
             key_args = {
                 'aws_access_key_id': self.config.aws_access_key_id,
-                'aws_secret_access_key': self.config.aws_secret_access_key
+                'aws_secret_access_key': self.config.aws_secret_access_key,
+                'aws_session_token': self.config.aws_session_token
             }
 
         warnings.filterwarnings('ignore', category=ResourceWarning, message='unclosed.*<ssl.SSLSocket.*>')


### PR DESCRIPTION
Added a config parameter `aws_session_token` that allows configuring libraries with `SHConfig` instances with temporary IAM credentials that are usually used at EC2 machines (access id, key and STS token are all required to initialize `boto3`).