### PR TITLE
Remove dependency on wheel

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-wheel
 requests>=2.5.0
 click
 numpy


### PR DESCRIPTION
This package does not depend on `wheel` being installed to run - there are no imports of `wheel` in the code. Indeed it's not even distributed as a wheel :)