### PR TITLE
Fathom analytics.

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -137,6 +137,11 @@ html_logo = './sentinel-hub-by_sinergise-dark_background.png'
 #    ]
 # }
 
+# analytics 
+html_js_files = [
+    ('https://cdn.usefathom.com/script.js', {'data-site': 'BILSIGFB', 'defer':'defer'})
+]
+
 
 # -- Options for HTMLHelp output ------------------------------------------
 


### PR DESCRIPTION
Removing GA analytics (from readthedocs, opting for GDPR compliant one). 