### PR TITLE
Modifications to support S2 v04.00

### DIFF
--- a/sentinelhub/aws.py
+++ b/sentinelhub/aws.py
@@ -640,7 +640,7 @@ class AwsTile(AwsService):
         """
         return f'{self.tile_url}/qi/{metafile}'
 
-    def get_gml_url(self, qi_type, band='B00'):
+    def get_gml_url(self, qi_type, band='B00', data_format=MimeType.GML):
         """
         :param qi_type: type of quality indicator
         :type qi_type: str
@@ -650,7 +650,9 @@ class AwsTile(AwsService):
         :rtype: str
         """
         band = band.split('/')[-1]
-        return self.get_qi_url(f'MSK_{qi_type}_{band}.gml')
+        if data_format == MimeType.JP2:
+            return self.get_qi_url(f'{qi_type}_{band}.{data_format.value}')
+        return self.get_qi_url(f'MSK_{qi_type}_{band}.{data_format.value}')
 
     def get_preview_url(self, data_type='L1C'):
         """Returns url location of full resolution L1C preview

--- a/sentinelhub/aws_safe.py
+++ b/sentinelhub/aws_safe.py
@@ -219,12 +219,22 @@ class SafeTile(AwsTile):
                     safe[main_folder][AwsConstants.IMG_DATA][resolution][self.get_img_name(band, resolution)] =\
                         self.get_url(band_name)
 
+        # account for changes in data format and naming in S2 v04.00 (20220125)
+        if self.baseline >= '04.00':
+            qi_list = AwsConstants.QI_LIST_v4
+            qi_data_format = MimeType.JP2
+        else:
+            qi_list = AwsConstants.QI_LIST
+            qi_data_format = MimeType.GML
+
         safe[main_folder][AwsConstants.QI_DATA] = {}
-        safe[main_folder][AwsConstants.QI_DATA][self.get_qi_name('CLOUDS')] = self.get_gml_url('CLOUDS')
-        for qi_type in AwsConstants.QI_LIST:
+        safe[main_folder][AwsConstants.QI_DATA][self.get_qi_name('CLOUDS', data_format=qi_data_format)] = \
+            self.get_gml_url('CLOUDS', data_format=qi_data_format)
+
+        for qi_type in qi_list:
             for band in AwsConstants.S2_L1C_BANDS:
-                safe[main_folder][AwsConstants.QI_DATA][self.get_qi_name(qi_type, band)] = self.get_gml_url(qi_type,
-                                                                                                            band)
+                safe[main_folder][AwsConstants.QI_DATA][self.get_qi_name(qi_type, band, data_format=qi_data_format)] = \
+                    self.get_gml_url(qi_type, band, data_format=qi_data_format)
 
         if self.has_reports():
             for metafile in AwsConstants.QUALITY_REPORTS:

--- a/sentinelhub/constants.py
+++ b/sentinelhub/constants.py
@@ -471,6 +471,7 @@ class AwsConstants:
     PREVIEW = 'preview'
     PREVIEW_JP2 = 'preview*'
     QI_LIST = ['DEFECT', 'DETFOO', 'NODATA', 'SATURA', 'TECQUA']
+    QI_LIST_v4 = ['DETFOO', 'QUALIT']
     QI_MSK_CLOUD = 'qi/MSK_CLOUDS_B00'
     AUX_DATA = 'AUX_DATA'
     DATASTRIP = 'DATASTRIP'
@@ -519,6 +520,7 @@ class AwsConstants:
                        [f'{preview}/{band}' for preview, band in it.zip_longest([], S2_L1C_BANDS, fillvalue=PREVIEW)] +\
                        [QI_MSK_CLOUD] +\
                        [f'qi/MSK_{qi}_{band}' for qi, band in it.product(QI_LIST, S2_L1C_BANDS)] + \
+                       [f'qi/{qi}_{band}' for qi, band in it.product(QI_LIST_v4, S2_L1C_BANDS)] + \
                        [f'qi/{qi_report}' for qi_report in [FORMAT_CORRECTNESS, GENERAL_QUALITY,
                                                             GEOMETRIC_QUALITY, SENSOR_QUALITY]] +\
                        [ECMWFT]
@@ -530,7 +532,8 @@ class AwsConstants:
                         DATASTRIP_METADATA] + [f'datastrip/*/qi/{qi_report}' for qi_report in QUALITY_REPORTS] +\
                        [f'qi/{source_id}_PVI' for source_id in SOURCE_ID_LIST] +\
                        [f'qi/{mask}_{res.lstrip("R")}' for mask, res in it.product(CLASS_MASKS, [R20m, R60m])] +\
-                       [f'qi/MSK_{qi}_{band}' for qi, band in it.product(QI_LIST, S2_L1C_BANDS)] +\
+                       [f'qi/MSK_{qi}_{band}' for qi, band in it.product(QI_LIST, S2_L1C_BANDS)] + \
+                       [f'qi/{qi}_{band}' for qi, band in it.product(QI_LIST_v4, S2_L1C_BANDS)] + \
                        [QI_MSK_CLOUD] +\
                        [f'qi/{qi_report}' for qi_report in QUALITY_REPORTS] +\
                        [ECMWFT, AUX_ECMWFT, GIPP]


### PR DESCRIPTION
Support the v04.00 processing baseline from ESA and allow the downloaded products to be used with FMask.