### PR TITLE
Increased cache size for pyproj objects

### DIFF
--- a/sentinelhub/constants.py
+++ b/sentinelhub/constants.py
@@ -189,31 +189,37 @@ class CRS(Enum, metaclass=CRSMeta):
         """
         return self.name.startswith("UTM")
 
-    @functools.lru_cache(maxsize=5)
+    @functools.lru_cache(maxsize=100)
     def projection(self):
-        """Returns a projection in form of pyproj class. For better time performance it will cache results of
-        5 most recently used CRS classes.
+        """Returns a projection in form of pyproj class.
+
+        For better time performance this method will cache `100` most recent results. Cache can be released with
+        `CRS.projection.cache_clear()`.
 
         :return: pyproj projection class
         :rtype: pyproj.Proj
         """
         return pyproj.Proj(self._get_pyproj_projection_def(), preserve_units=True)
 
-    @functools.lru_cache(maxsize=5)
+    @functools.lru_cache(maxsize=100)
     def pyproj_crs(self):
-        """Returns a pyproj CRS class. For better time performance it will cache results of
-        5 most recently used CRS classes.
+        """Returns a pyproj CRS class.
+
+        For better time performance this method will cache `100` most recent results. Cache can be released with
+        `CRS.pyproj_crs.cache_clear()`.
 
         :return: pyproj CRS class
         :rtype: pyproj.CRS
         """
         return pyproj.CRS(self._get_pyproj_projection_def())
 
-    @functools.lru_cache(maxsize=10)
+    @functools.lru_cache(maxsize=10 ** 4)
     def get_transform_function(self, other, always_xy=True):
         """Returns a function for transforming geometrical objects from one CRS to another. The function will support
         transformations between any objects that pyproj supports.
-        For better time performance this method will cache results of 10 most recently used pairs of CRS classes.
+
+        For better time performance this method will cache results. Cache can be released with
+        `CRS.get_transform_function.cache_clear()`.
 
         :param self: Initial CRS
         :type self: CRS

--- a/sentinelhub/constants.py
+++ b/sentinelhub/constants.py
@@ -193,7 +193,7 @@ class CRS(Enum, metaclass=CRSMeta):
     def projection(self):
         """Returns a projection in form of pyproj class.
 
-        For better time performance this method will cache `100` most recent results. Cache can be released with
+        For better time performance this method will cache `128` most recent results. Cache can be released with
         `CRS.projection.cache_clear()`.
 
         :return: pyproj projection class
@@ -205,7 +205,7 @@ class CRS(Enum, metaclass=CRSMeta):
     def pyproj_crs(self):
         """Returns a pyproj CRS class.
 
-        For better time performance this method will cache `100` most recent results. Cache can be released with
+        For better time performance this method will cache `128` most recent results. Cache can be released with
         `CRS.pyproj_crs.cache_clear()`.
 
         :return: pyproj CRS class

--- a/sentinelhub/constants.py
+++ b/sentinelhub/constants.py
@@ -189,7 +189,7 @@ class CRS(Enum, metaclass=CRSMeta):
         """
         return self.name.startswith("UTM")
 
-    @functools.lru_cache(maxsize=150)
+    @functools.lru_cache(maxsize=128)
     def projection(self):
         """Returns a projection in form of pyproj class.
 
@@ -201,7 +201,7 @@ class CRS(Enum, metaclass=CRSMeta):
         """
         return pyproj.Proj(self._get_pyproj_projection_def(), preserve_units=True)
 
-    @functools.lru_cache(maxsize=150)
+    @functools.lru_cache(maxsize=128)
     def pyproj_crs(self):
         """Returns a pyproj CRS class.
 
@@ -213,7 +213,7 @@ class CRS(Enum, metaclass=CRSMeta):
         """
         return pyproj.CRS(self._get_pyproj_projection_def())
 
-    @functools.lru_cache(maxsize=600)
+    @functools.lru_cache(maxsize=512)
     def get_transform_function(self, other, always_xy=True):
         """Returns a function for transforming geometrical objects from one CRS to another. The function will support
         transformations between any objects that pyproj supports.

--- a/sentinelhub/constants.py
+++ b/sentinelhub/constants.py
@@ -189,7 +189,7 @@ class CRS(Enum, metaclass=CRSMeta):
         """
         return self.name.startswith("UTM")
 
-    @functools.lru_cache(maxsize=100)
+    @functools.lru_cache(maxsize=150)
     def projection(self):
         """Returns a projection in form of pyproj class.
 
@@ -201,7 +201,7 @@ class CRS(Enum, metaclass=CRSMeta):
         """
         return pyproj.Proj(self._get_pyproj_projection_def(), preserve_units=True)
 
-    @functools.lru_cache(maxsize=100)
+    @functools.lru_cache(maxsize=150)
     def pyproj_crs(self):
         """Returns a pyproj CRS class.
 
@@ -213,7 +213,7 @@ class CRS(Enum, metaclass=CRSMeta):
         """
         return pyproj.CRS(self._get_pyproj_projection_def())
 
-    @functools.lru_cache(maxsize=10**4)
+    @functools.lru_cache(maxsize=600)
     def get_transform_function(self, other, always_xy=True):
         """Returns a function for transforming geometrical objects from one CRS to another. The function will support
         transformations between any objects that pyproj supports.

--- a/sentinelhub/constants.py
+++ b/sentinelhub/constants.py
@@ -213,7 +213,7 @@ class CRS(Enum, metaclass=CRSMeta):
         """
         return pyproj.CRS(self._get_pyproj_projection_def())
 
-    @functools.lru_cache(maxsize=10 ** 4)
+    @functools.lru_cache(maxsize=10**4)
     def get_transform_function(self, other, always_xy=True):
         """Returns a function for transforming geometrical objects from one CRS to another. The function will support
         transformations between any objects that pyproj supports.


### PR DESCRIPTION
The problem is that it takes about 100ms to initialize each `pyproj` object and the size of each one in memory is almost 1MB. Therefore, we neither want to initialize `pyproj` objects many times nor we want to keep many of them in memory. But usually we need to make a transformation between CRSs many times, hence we cache `pyproj` objects.

We used to think that low `maxsize` cache limits were completely sufficient for more or less all use cases. But I recently had a use case of running a batch job with 300K tiles from 20 different UTM zones. [Here in `BatchSplitter`](https://github.com/sentinel-hub/sentinelhub-py/blob/v3.5.0/sentinelhub/areas.py#L727), tiles are being transformed from WGS84 to its native UTM CRSs. It turns out the service is returning batch tiles in some arbitrary order and not grouped by UTM zones. Because cache sizes weren't large enough for constantly switching transformations between 20 target UTM zones that meant `pyproj` objects had to be recreated a lot of times. Hence, this step took 3 hours instead of 1 minute.

Technically, this particular problem could also be solved in `BatchSplitter` by first sorting tiles by UTMs. It would even be possible to reconstruct the original order of tiles after transformations. But I'm sure this issue can appear also outside `BatchSplitter` and it would be very difficult for users to figure out the reason for slow performance.

Therefore, the proposed solution is to significantly increase cache sizes and in case anyone will ever have memory issues I documented a way how to release cache without having to restart Python process.