### PR TITLE
Feat/tokeninfo

### DIFF
--- a/sentinelhub/download/session.py
+++ b/sentinelhub/download/session.py
@@ -65,7 +65,7 @@ class SentinelHubSession:
         """Decode token to get token info"""
 
         token = self.token["access_token"].split(".")[1]
-        padded = token + "=" * divmod(len(token), 4)[1]
+        padded = token + "=" * (len(token) % 4)
         decoded_string = base64.b64decode(padded).decode()
         return json.loads(decoded_string)
 

--- a/sentinelhub/download/session.py
+++ b/sentinelhub/download/session.py
@@ -1,6 +1,8 @@
 """
 Module implementing Sentinel Hub session object
 """
+import base64
+import json
 import logging
 import time
 
@@ -58,6 +60,14 @@ class SentinelHubSession:
         self._token = self._fetch_token(request)
 
         return self._token
+
+    def info(self):
+        """Decode token to get token info"""
+
+        token = self.token["access_token"].split(".")[1]
+        padded = token + "=" * divmod(len(token), 4)[1]
+        decoded_string = base64.b64decode(padded).decode()
+        return json.loads(decoded_string)
 
     @property
     def session_headers(self):

--- a/tests/download/test_session.py
+++ b/tests/download/test_session.py
@@ -6,8 +6,6 @@ from sentinelhub import SentinelHubSession
 @pytest.fixture(name="session", scope="module")
 def session_fixture():
     session = SentinelHubSession()
-    # pre-fetch token
-    session.token
     return session
 
 

--- a/tests/download/test_session.py
+++ b/tests/download/test_session.py
@@ -3,11 +3,16 @@ import pytest
 from sentinelhub import SentinelHubSession
 
 
-@pytest.mark.sh_integration
-def test_session():
-
+@pytest.fixture(name="session")
+def session_fixture():
     session = SentinelHubSession()
+    # pre-fetch token
+    session.token
+    return session
 
+
+@pytest.mark.sh_integration
+def test_session(session):
     token = session.token
     headers = session.session_headers
 
@@ -23,3 +28,11 @@ def test_session():
     token["expires_at"] = 0
     new_token = session.token
     assert token["access_token"] != new_token["access_token"], "The token has not been refreshed"
+
+
+@pytest.mark.sh_integration
+def test_token_info(session):
+    info = session.info()
+
+    for key in ["sub", "aud", "jti", "exp", "name", "email", "sid", "org", "did", "aid", "d"]:
+        assert key in info

--- a/tests/download/test_session.py
+++ b/tests/download/test_session.py
@@ -3,7 +3,7 @@ import pytest
 from sentinelhub import SentinelHubSession
 
 
-@pytest.fixture(name="session")
+@pytest.fixture(name="session", scope="module")
 def session_fixture():
     session = SentinelHubSession()
     # pre-fetch token


### PR DESCRIPTION
This PR adds a method to `SentinelHubSession` that parses the token to obtain tokeninfo. 

Disclaimer: Same information can be obtained at `tokeninfo` endpoint, but decoding it saves a request.