### PR TITLE
Add py.typed file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,4 +4,5 @@ include README.md
 include LICENSE.md
 include setup.py
 include sentinelhub/config.json
+include sentinelhub/py.typed
 include sentinelhub/.utmzones.geojson

--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ setup(
     author_email="info@sentinel-hub.com",
     license="MIT",
     packages=find_packages(),
-    package_data={"sentinelhub": ["sentinelhub/config.json", "sentinelhub/.utmzones.geojson"]},
+    package_data={"sentinelhub": ["sentinelhub/config.json", "sentinelhub/.utmzones.geojson", "sentinelhub/py.typed"]},
     include_package_data=True,
     install_requires=parse_requirements("requirements.txt"),
     extras_require={


### PR DESCRIPTION
While the type annotations are severely lacking at this point, it still allows `mypy` to differentiate between different shpy classes in other packages.