### PR TITLE
More type annotations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,6 +101,7 @@ ENV/
 
 # mypy
 .mypy_cache/
+.dmypy.json
 
 # Test output folder
 /TestOutputs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,3 +25,21 @@ omit = [
     "config.json",
     ".utmzones.geojson"
 ]
+
+[tool.mypy]
+follow_imports = "normal"
+ignore_missing_imports = true
+show_column_numbers = true
+show_error_codes = true
+no_implicit_optional = true
+warn_redundant_casts = true
+warn_unused_ignores = true
+# disallow_untyped_defs = true
+# disallow_untyped_decorators = true
+warn_unreachable = true
+strict_equality = true
+# these ones are really strict, maybe later
+# no_implicit_reexport = true  # this one has issues with eolearn not specifying __all__ when reexporting
+# disallow_untyped_calls = true
+# disallow_any_generics = true
+# warn_return_any = true

--- a/sentinelhub/commands.py
+++ b/sentinelhub/commands.py
@@ -2,14 +2,18 @@
 Module that implements command line interface for the package
 """
 
+from typing import Any, Callable, TypeVar
+
 import click
 
 from .config import SHConfig
 from .download import DownloadClient, DownloadRequest
 
+FC = TypeVar("FC", bound=Callable[..., Any])
+
 
 @click.command()
-def main_help():
+def main_help() -> None:
     """
     Welcome to sentinelhub Python library command line help.
 
@@ -24,7 +28,7 @@ def main_help():
     """
 
 
-def _config_options(func):
+def _config_options(func: FC) -> FC:
     """A helper function which joins click.option functions of each parameter from config.json"""
     for param in SHConfig().get_params()[-1::-1]:
         func = click.option(f"--{param}", param, help=f'Set new values to configuration parameter "{param}"')(func)
@@ -35,7 +39,7 @@ def _config_options(func):
 @click.option("--show", is_flag=True, default=False, help="Show current configuration")
 @click.option("--reset", is_flag=True, default=False, help="Reset configuration to initial state")
 @_config_options
-def config(show, reset, **params):
+def config(show: bool, reset: bool, **params: Any) -> None:
     """Inspect and configure parameters in your local sentinelhub configuration file
 
     \b
@@ -80,7 +84,7 @@ def config(show, reset, **params):
 @click.argument("url")
 @click.argument("filename", type=click.Path())
 @click.option("-r", "--redownload", is_flag=True, default=False, help="Redownload existing files")
-def download(url, filename, redownload):
+def download(url: str, filename: str, redownload: bool) -> None:
     """Download from custom created URL into custom created file path
 
     \b

--- a/sentinelhub/os_utils.py
+++ b/sentinelhub/os_utils.py
@@ -5,48 +5,42 @@ Module for managing files and folders
 import errno
 import os
 from sys import platform
+from typing import List
 
 
-def get_content_list(folder="."):
+def get_content_list(folder: str = ".") -> List[str]:
     """Get list of contents in input folder
 
     :param folder: input folder to list contents. Default is ``'.'``
-    :type folder: str
     :return: list of folder contents
-    :rtype: list(str)
     """
     return os.listdir(folder)
 
 
-def get_folder_list(folder="."):
+def get_folder_list(folder: str = ".") -> List[str]:
     """Get list of sub-folders contained in input folder
 
     :param folder: input folder to list sub-folders. Default is ``'.'``
-    :type folder: str
     :return: list of sub-folders
-    :rtype: list(str)
     """
     dir_list = get_content_list(folder)
     return [f for f in dir_list if not os.path.isfile(os.path.join(folder, f))]
 
 
-def get_file_list(folder="."):
+def get_file_list(folder: str = ".") -> List[str]:
     """Get list of files contained in input folder
 
     :param folder: input folder to list files only. Default is ``'.'``
-    :type folder: str
     :return: list of files
-    :rtype: list(str)
     """
     dir_list = get_content_list(folder)
     return [f for f in dir_list if os.path.isfile(os.path.join(folder, f))]
 
 
-def create_parent_folder(filename):
+def create_parent_folder(filename: str) -> None:
     """Create parent folder for input filename recursively
 
     :param filename: input filename
-    :type filename: str
     :raises: error if folder cannot be created
     """
     path = os.path.dirname(filename)
@@ -54,14 +48,13 @@ def create_parent_folder(filename):
         make_folder(path)
 
 
-def make_folder(path):
+def make_folder(path: str) -> None:
     """Create folder at input path recursively
 
     Create a folder specified by input path if one
     does not exist already
 
     :param path: input path to folder to be created
-    :type path: str
     :raises: os.error if folder cannot be created
     """
     if not os.path.exists(path):
@@ -74,15 +67,12 @@ def make_folder(path):
                 ) from exception
 
 
-def rename(old_path, new_path, edit_folders=True):
+def rename(old_path: str, new_path: str, edit_folders: bool = True) -> None:
     """Rename files or folders
 
     :param old_path: name of file or folder to rename
     :param new_path: name of new file or folder
     :param edit_folders: flag to allow recursive renaming of folders. Default is `True`
-    :type old_path: str
-    :type new_path: str
-    :type edit_folders: bool
     """
     if edit_folders:
         os.renames(old_path, new_path)
@@ -90,13 +80,11 @@ def rename(old_path, new_path, edit_folders=True):
         os.rename(old_path, new_path)
 
 
-def size(pathname):
+def size(pathname: str) -> int:
     """Returns size of a file or folder in Bytes
 
     :param pathname: path to file or folder to be sized
-    :type pathname: str
     :return: size of file or folder in Bytes
-    :rtype: int
     :raises: os.error if file is not accessible
     """
     if os.path.isfile(pathname):
@@ -104,10 +92,9 @@ def size(pathname):
     return sum([size(f"{pathname}/{name}") for name in get_content_list(pathname)])
 
 
-def sys_is_windows():
+def sys_is_windows() -> bool:
     """Check if user is running the code on Windows machine
 
     :return: `True` if OS is Windows and `False` otherwise
-    :rtype: bool
     """
     return platform.lower().startswith("win")

--- a/sentinelhub/testing_utils.py
+++ b/sentinelhub/testing_utils.py
@@ -2,52 +2,44 @@
 Utility tools for writing unit tests for packages which rely on `sentinelhub-py`
 """
 import os
+from typing import Optional, Tuple
 
 import numpy as np
 from pytest import approx
 
 
-def get_input_folder(current_file):
+def get_input_folder(current_file: str) -> str:
     """Use fixtures if possible. This is meant only for test cases"""
     return os.path.join(os.path.dirname(os.path.realpath(current_file)), "TestInputs")
 
 
-def get_output_folder(current_file):
+def get_output_folder(current_file: str) -> str:
     """Use fixtures if possible. This is meant only for test cases"""
     return os.path.join(os.path.dirname(os.path.realpath(current_file)), "TestOutputs")
 
 
 def test_numpy_data(
-    data=None,
-    exp_shape=None,
-    exp_dtype=None,
-    exp_min=None,
-    exp_max=None,
-    exp_mean=None,
-    exp_median=None,
-    exp_std=None,
-    delta=None,
-):
+    data: Optional[np.ndarray] = None,
+    exp_shape: Optional[Tuple[int, ...]] = None,
+    exp_dtype: Optional[np.dtype] = None,
+    exp_min: Optional[float] = None,
+    exp_max: Optional[float] = None,
+    exp_mean: Optional[float] = None,
+    exp_median: Optional[float] = None,
+    exp_std: Optional[float] = None,
+    delta: Optional[float] = None,
+) -> None:
     """Validates basic statistics of data array
 
     :param data: Data array
-    :type data: numpy.ndarray
     :param exp_shape: Expected shape
-    :type exp_shape: tuple(int)
     :param exp_dtype: Expected dtype
-    :type exp_dtype: numpy.dtype
     :param exp_min: Expected minimal value
-    :type exp_min: float
     :param exp_max: Expected maximal value
-    :type exp_max: float
     :param exp_mean: Expected mean value
-    :type exp_mean: float
     :param exp_median: Expected median value
-    :type exp_median: float
     :param exp_std: Expected standard deviation value
-    :type exp_std: float
     :param delta: Precision of validation (relative). If not set, it will be set automatically
-    :type delta: float
     """
     if data is None:
         return
@@ -68,7 +60,7 @@ def test_numpy_data(
     data_stats, exp_stats = {}, {}
     for name, (func, expected) in stats_suite.items():
         if expected is not None:
-            data_stats[name] = func(data)
+            data_stats[name] = func(data)  # type: ignore # unknown function
             exp_stats[name] = expected if name in is_precise else approx(expected, rel=delta)
 
     assert data_stats == exp_stats, "Statistics differ from expected values"


### PR DESCRIPTION
Since `py.typed` is included we can now start adding type annotations. This won't be easy so we should probably start with the low-hanging fruit and work our way to (possibly code-breaking) large changes.

I believe we should do this change gradually and in many small MRs so that the changes are actually looked at.

I tried to change the code itself as little as possible. In some places the precise types are rather verbose (a tuple of 4 tuples and the likes...)