### PR TITLE
Improved parsing of WGS84 in CRS class

### DIFF
--- a/sentinelhub/constants.py
+++ b/sentinelhub/constants.py
@@ -129,6 +129,9 @@ class CRSMeta(EnumMeta):
             if epsg_code is not None:
                 return str(epsg_code)
 
+            if value == CRS.WGS84.pyproj_crs():
+                return "4326"
+
             error_message = f"Failed to determine an EPSG code of the given CRS:\n{repr(value)}"
             maybe_epsg = value.to_epsg(min_confidence=0)
             if maybe_epsg is not None:

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -1,4 +1,6 @@
-import warnings
+"""
+Tests for constants.py module
+"""
 
 import numpy as np
 import pyproj
@@ -35,6 +37,7 @@ def test_utm(lng, lat, epsg):
         ("EPSG:3857", CRS.POP_WEB),
         ({"init": "EPSG:32638"}, CRS.UTM_38N),
         (pyproj.CRS("+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs"), CRS.WGS84),
+        (pyproj.CRS(CRS.WGS84.pyproj_crs().to_wkt()), CRS.WGS84),
         ("urn:ogc:def:crs:epsg::32631", CRS.UTM_31N),
         ("urn:ogc:def:crs:OGC::CRS84", CRS.WGS84),
         (pyproj.CRS(3857), CRS.POP_WEB),
@@ -50,15 +53,6 @@ def test_crs_parsing_warn(parse_value, expected, warning):
     with pytest.warns(warning):
         parsed_result = CRS(parse_value)
         assert parsed_result == expected
-
-
-def test_failed_crs_parsing():
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
-        wgs84_with_init = pyproj.CRS({"init": "epsg:4326"})
-
-    with pytest.raises(ValueError):
-        CRS(wgs84_with_init)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
We define WGS 84 in pyproj with reversed coordinates and transforming such object to EPSG code works:

```Python
from pyproj import CRS

CRS("+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs").to_epsg()

>> 4326
```

But, as far as I understand, during saving to Geopackage and loading from Geopackage the following happens with the object:

```Python
from pyproj import CRS

wgs84 = CRS("+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs")
new_wgs84 = CRS(wgs84.to_wkt())
new_wgs84.to_epsg()

>> None
```

Because EPSG code somehow can't be reconstructed this becomes an issue in `sentinelhub.CRS` parsing. The fix relies on the following:

```Python
from pyproj import CRS

wgs84 = CRS("+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs")
new_wgs84 = CRS(wgs84.to_wkt())
wgs84 == new_wgs84

>> True
```

Basically, we start relying more on the equality function than on `to_epsg`.