### PR TITLE
Fixed issue of passing SHConfig to Ray

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,4 +9,4 @@ isort
 pillow>=9.0.0
 rasterio;python_version<"3.10"
 click>=8.0.0
-ray
+ray[default]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,3 +9,4 @@ isort
 pillow>=9.0.0
 rasterio;python_version<"3.10"
 click>=8.0.0
+ray

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,6 +7,6 @@ requests-mock
 black[jupyter]>=22.1.0
 isort
 pillow>=9.0.0
-rasterio;python_version<"3.10"
 click>=8.0.0
-ray[default]
+rasterio;python_version<"3.10"
+ray[default];python_version<"3.10"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,3 +50,13 @@ def logger_fixture():
         level=logging.INFO, format="%(asctime)-15s %(module)s:%(lineno)d [%(levelname)s] %(funcName)s  %(message)s"
     )
     return logging.getLogger(__name__)
+
+
+@pytest.fixture(name="ray")
+def ray_fixture():
+    """Ensures that the ray server will stop even if test fails"""
+    ray = pytest.importorskip("ray")
+    ray.init(log_to_driver=False)
+
+    yield ray
+    ray.shutdown()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -137,7 +137,7 @@ def test_transfer_with_ray(ray):
 
     def _remote_ray_testing(remote_config):
         """Makes a few checks and modifications to the config object"""
-        assert repr(remote_config).startswith('SHConfig')
+        assert repr(remote_config).startswith("SHConfig")
         assert isinstance(remote_config.get_config_dict(), dict)
         assert os.path.exists(remote_config.get_config_location())
         assert remote_config.instance_id == "x"
@@ -148,5 +148,5 @@ def test_transfer_with_ray(ray):
     config_future = ray.remote(_remote_ray_testing).remote(config)
     transferred_config = ray.get(config_future)
 
-    assert repr(config).startswith('SHConfig')
+    assert repr(config).startswith("SHConfig")
     assert transferred_config.instance_id == "y"

--- a/tests/test_data_collections.py
+++ b/tests/test_data_collections.py
@@ -125,18 +125,8 @@ def helper_check_collection_list(collection_list):
     return is_list and contains_collections
 
 
-@pytest.fixture(name="ray")
-def ray_fixture():
-    """Ensures that the ray server will stop even if test fails"""
-    ray = pytest.importorskip("ray")
-    ray.init(log_to_driver=False)
-
-    yield ray
-    ray.shutdown()
-
-
 def test_transfer_with_ray(ray):
-    """This tests makes sure that the process of transferring a custom DataCollection object to a Ray worker and back
+    """This test makes sure that the process of transferring a custom DataCollection object to a Ray worker and back
     works correctly.
     """
     collection = DataCollection.SENTINEL2_L1C.define_from("MY_NEW_COLLECTION", api_id="xxx")


### PR DESCRIPTION
The problem was that when an instance of `SHConfig` would be passed to a Ray worker it would lose `self._instance` because that is defined only as a class attribute. However, `self._instance` was being called in many methods, even in `__repr__`. So calling `repr(config)` on Ray worker would fail.

The PR only contains a fix and an extra test for this.More improvements will be done in near future where we will also aim to get autocomplete for config parameters.

This PR also removes and limits some overrides of `__getatt__` and `__getitem__` methods and also puts adds Ray to development requirements for Python version `<3.10`.