### PR TITLE
Types in `areas.py`

### DIFF
--- a/sentinelhub/areas.py
+++ b/sentinelhub/areas.py
@@ -29,12 +29,15 @@ class AreaSplitter(metaclass=ABCMeta):
     parts.
     """
 
-    def __init__(self, shape_list, crs, reduce_bbox_sizes=False):
+    def __init__(
+        self,
+        shape_list: Iterable[Union[Polygon, MultiPolygon, _BaseGeometry]],
+        crs: CRS,
+        reduce_bbox_sizes: bool = False,
+    ):
         """
         :param shape_list: A list of geometrical shapes describing the area of interest
-        :type shape_list: list(shapely.geometry.multipolygon.MultiPolygon or shapely.geometry.polygon.Polygon)
         :param crs: Coordinate reference system of the shapes in `shape_list`
-        :type crs: CRS
         :param reduce_bbox_sizes: If `True` it will reduce the sizes of bounding boxes so that they will tightly fit
             the given geometry in `shape_list`.
         """
@@ -47,11 +50,12 @@ class AreaSplitter(metaclass=ABCMeta):
         self.bbox_list, self.info_list = self._make_split()
 
     @staticmethod
-    def _parse_shape_list(shape_list, crs):
+    def _parse_shape_list(
+        shape_list: Iterable[Union[Polygon, MultiPolygon, _BaseGeometry]], crs: CRS
+    ) -> List[Union[Polygon, MultiPolygon]]:
         """Checks if the given list of shapes is in correct format and parses geometry objects
 
         :param shape_list: The parameter `shape_list` from class initialization
-        :type shape_list: list(shapely.geometry.multipolygon.MultiPolygon or shapely.geometry.polygon.Polygon)
         :raises: ValueError
         """
         if not isinstance(shape_list, list):
@@ -60,7 +64,7 @@ class AreaSplitter(metaclass=ABCMeta):
         return [AreaSplitter._parse_shape(shape, crs) for shape in shape_list]
 
     @staticmethod
-    def _parse_shape(shape, crs):
+    def _parse_shape(shape: Union[Polygon, MultiPolygon, _BaseGeometry], crs: CRS) -> Union[Polygon, MultiPolygon]:
         """Helper method for parsing input shapes"""
         if isinstance(shape, (Polygon, MultiPolygon)):
             return shape
@@ -71,36 +75,34 @@ class AreaSplitter(metaclass=ABCMeta):
         )
 
     @staticmethod
-    def _join_shape_list(shape_list):
+    def _join_shape_list(shape_list: List[Union[Polygon, MultiPolygon]]) -> MultiPolygon:
         """Joins a list of shapes together into one shape
 
         :param shape_list: A list of geometrical shapes describing the area of interest
-        :type shape_list: list(shapely.geometry.multipolygon.MultiPolygon or shapely.geometry.polygon.Polygon)
         :return: A multipolygon which is a union of shapes in given list
-        :rtype: shapely.geometry.multipolygon.MultiPolygon
         """
         if shapely.__version__ >= "1.8.0":
             return shapely.ops.unary_union(shape_list)
         return shapely.ops.cascaded_union(shape_list)
 
     @abstractmethod
-    def _make_split(self):
+    def _make_split(self) -> Tuple[List[BBox], List[Dict[str, object]]]:
         """The abstract method where the splitting will happen"""
-        raise NotImplementedError
 
-    def get_bbox_list(self, crs=None, buffer=None, reduce_bbox_sizes=None):
+    def get_bbox_list(
+        self,
+        crs: Optional[CRS] = None,
+        buffer: Union[None, float, Tuple[float, float]] = None,
+        reduce_bbox_sizes: Optional[bool] = None,
+    ) -> List[BBox]:
         """Returns a list of bounding boxes that are the result of the split
 
         :param crs: Coordinate reference system in which the bounding boxes should be returned. If `None` the CRS will
             be the default CRS of the splitter.
-        :type crs: CRS or None
         :param buffer: A percentage of each BBox size increase. This will cause neighbouring bounding boxes to overlap.
-        :type buffer: (float, float) or float or None
         :param reduce_bbox_sizes: If `True` it will reduce the sizes of bounding boxes so that they will tightly
             fit the given geometry in `shape_list`. This overrides the same parameter from constructor
-        :type reduce_bbox_sizes: bool
         :return: List of bounding boxes
-        :rtype: list(BBox)
         """
         bbox_list = self.bbox_list
         if buffer:
@@ -115,40 +117,35 @@ class AreaSplitter(metaclass=ABCMeta):
             return [bbox.transform(crs) for bbox in bbox_list]
         return bbox_list
 
-    def get_geometry_list(self):
+    def get_geometry_list(self) -> List[Union[Polygon, MultiPolygon]]:
         """For each bounding box an intersection with the shape of entire given area is calculated. CRS of the returned
         shapes is the same as CRS of the given area.
 
         :return: List of polygons or multipolygons corresponding to the order of bounding boxes
-        :rtype: list(shapely.geometry.multipolygon.MultiPolygon or shapely.geometry.polygon.Polygon)
         """
         return [self._intersection_area(bbox) for bbox in self.bbox_list]
 
-    def get_info_list(self):
+    def get_info_list(self) -> List[Dict[str, object]]:
         """Returns a list of dictionaries containing information about bounding boxes obtained in split. The order in
         the list matches the order of the list of bounding boxes.
 
         :return: List of dictionaries
-        :rtype: list(BBox)
         """
         return self.info_list
 
-    def get_area_shape(self):
+    def get_area_shape(self) -> MultiPolygon:
         """Returns a single shape of entire area described with `shape_list` parameter
 
         :return: A multipolygon which is a union of shapes describing the area
-        :rtype: shapely.geometry.multipolygon.MultiPolygon
         """
         return self.area_shape
 
-    def get_area_bbox(self, crs=None):
+    def get_area_bbox(self, crs: Optional[CRS] = None) -> BBox:
         """Returns a bounding box of the entire area
 
         :param crs: Coordinate reference system in which the bounding box should be returned. If `None` the CRS will
             be the default CRS of the splitter.
-        :type crs: CRS or None
         :return: A bounding box of the area defined by the `shape_list`
-        :rtype: BBox
         """
         bbox_list = [BBox(shape.bounds, crs=self.crs) for shape in self.shape_list]
         area_min_x = min([bbox.lower_left[0] for bbox in bbox_list])
@@ -160,38 +157,32 @@ class AreaSplitter(metaclass=ABCMeta):
             return bbox
         return bbox.transform(crs)
 
-    def _intersects_area(self, bbox):
+    def _intersects_area(self, bbox: BBox) -> bool:
         """Checks if the bounding box intersects the entire area
 
         :param bbox: A bounding box
-        :type bbox: BBox
         :return: `True` if bbox intersects the entire area else False
-        :rtype: bool
         """
         return self._bbox_to_area_polygon(bbox).intersects(self.area_shape)
 
-    def _intersection_area(self, bbox):
+    def _intersection_area(self, bbox: BBox) -> Union[Polygon, MultiPolygon]:
         """Calculates the intersection of a given bounding box and the entire area
 
         :param bbox: A bounding box
-        :type bbox: BBox
         :return: A shape of intersection
-        :rtype: shapely.geometry.multipolygon.MultiPolygon or shapely.geometry.polygon.Polygon
         """
         return self._bbox_to_area_polygon(bbox).intersection(self.area_shape)
 
-    def _bbox_to_area_polygon(self, bbox):
+    def _bbox_to_area_polygon(self, bbox: BBox) -> Polygon:
         """Transforms bounding box into a polygon object in the area CRS.
 
         :param bbox: A bounding box
-        :type bbox: BBox
         :return: A polygon
-        :rtype: shapely.geometry.polygon.Polygon
         """
         projected_bbox = bbox.transform(self.crs)
         return projected_bbox.geometry
 
-    def _reduce_sizes(self, bbox_list):
+    def _reduce_sizes(self, bbox_list: List[BBox]) -> List[BBox]:
         """Reduces sizes of bounding boxes"""
         return [BBox(self._intersection_area(bbox).bounds, self.crs).transform(bbox.crs) for bbox in bbox_list]
 
@@ -202,16 +193,19 @@ class BBoxSplitter(AreaSplitter):
     area. If specified by user it can also reduce the sizes of the remaining bounding boxes to best fit the area.
     """
 
-    def __init__(self, shape_list, crs, split_shape, **kwargs):
+    def __init__(
+        self,
+        shape_list: Iterable[Union[Polygon, MultiPolygon, _BaseGeometry]],
+        crs: CRS,
+        split_shape: Union[int, Tuple[int, int]],
+        **kwargs: Any,
+    ):
         """
         :param shape_list: A list of geometrical shapes describing the area of interest
-        :type shape_list: list(shapely.geometry.multipolygon.MultiPolygon or shapely.geometry.polygon.Polygon)
         :param crs: Coordinate reference system of the shapes in `shape_list`
-        :type crs: CRS
         :param split_shape: Parameter that describes the shape in which the area bounding box will be split.
             It can be a tuple of the form `(n, m)` which means the area bounding box will be split into `n` columns
             and `m` rows. It can also be a single integer `n` which is the same as `(n, n)`.
-        :type split_shape: int or (int, int)
         :param reduce_bbox_sizes: If `True` it will reduce the sizes of bounding boxes so that they will tightly fit
             the given area geometry from `shape_list`.
         """
@@ -230,6 +224,8 @@ class BBoxSplitter(AreaSplitter):
                 return split_x, split_y
 
         raise ValueError(f"Split parameter must be an integer or a tuple of 2 integers but {split_parameter} was given")
+
+    def _make_split(self) -> Tuple[List[BBox], List[Dict[str, object]]]:
         columns, rows = self.split_shape
         bbox_partition = self.area_bbox.get_partition(num_x=columns, num_y=rows)
 
@@ -251,30 +247,27 @@ class OsmSplitter(AreaSplitter):
     """
 
 
-    def __init__(self, shape_list, crs, zoom_level, **kwargs):
+    def __init__(
+        self,
+        shape_list: Iterable[Union[Polygon, MultiPolygon, _BaseGeometry]],
+        crs: CRS,
+        zoom_level: int,
+        **kwargs: Any,
+    ):
         """
         :param shape_list: A list of geometrical shapes describing the area of interest
-        :type shape_list: list(shapely.geometry.multipolygon.MultiPolygon or shapely.geometry.polygon.Polygon)
         :param crs: Coordinate reference system of the shapes in `shape_list`
-        :type crs: CRS
         :param zoom_level: A zoom level defined by OSM. Level 0 is entire world, level 1 splits the world into
             4 parts, etc.
-        :type zoom_level: int
         :param reduce_bbox_sizes: If `True` it will reduce the sizes of bounding boxes so that they will tightly fit
             the given area geometry from `shape_list`.
-        :type reduce_bbox_sizes: bool
         """
         self._POP_WEB_MAX = transform_point((180, 0), CRS.WGS84, CRS.POP_WEB)[0]  # pylint: disable=invalid-name
 
         self.zoom_level = zoom_level
         super().__init__(shape_list, crs, **kwargs)
 
-        self._make_split()
-
-    def _make_split(
-        self,
-    ):
-        """This method makes the split"""
+    def _make_split(self) -> Tuple[List[BBox], List[Dict[str, object]]]:
         self.area_bbox = self.get_area_bbox(CRS.POP_WEB)
         self._check_area_bbox()
 
@@ -284,7 +277,7 @@ class OsmSplitter(AreaSplitter):
             bbox_list[i] = bbox.transform(self.crs)
         return bbox_list, info_list
 
-    def _check_area_bbox(self):
+    def _check_area_bbox(self) -> None:
         """The method checks if the area bounding box is completely inside the OSM grid. That means that its latitudes
         must be contained in the interval (-85.0511, 85.0511)
 
@@ -296,25 +289,28 @@ class OsmSplitter(AreaSplitter):
                     "OsmTileSplitter only works for areas which have latitude in interval (-85.0511, 85.0511)"
                 )
 
-    def get_world_bbox(self):
+    def get_world_bbox(self) -> BBox:
         """Creates a bounding box of the entire world in EPSG: 3857
 
         :return: Bounding box of entire world
-        :rtype: BBox
         """
         return BBox((-self._POP_WEB_MAX, -self._POP_WEB_MAX, self._POP_WEB_MAX, self._POP_WEB_MAX), crs=CRS.POP_WEB)
 
-    def _recursive_split(self, bbox, zoom_level, column, row):
+    def _recursive_split(
+        self,
+        bbox: BBox,
+        zoom_level: int,
+        column: int,
+        row: int,
+        bbox_list: List[BBox],
+        info_list: List[Dict[str, object]],
+    ) -> Tuple[List[BBox], List[Dict[str, object]]]:
         """Method that recursively creates bounding boxes of OSM grid that intersect the area.
 
         :param bbox: Bounding box
-        :type bbox: BBox
         :param zoom_level: OSM zoom level
-        :type zoom_level: int
         :param column: Column in the OSM grid
-        :type column: int
         :param row: Row in the OSM grid
-        :type row: int
         """
         if zoom_level == self.zoom_level:
             bbox_list.append(bbox)
@@ -341,27 +337,28 @@ class TileSplitter(AreaSplitter):
         "exclude": [],
     }
 
-    def __init__(self, shape_list, crs, time_interval, data_collection, tile_split_shape=1, config=None, **kwargs):
+    def __init__(
+        self,
+        shape_list: Iterable[Union[Polygon, MultiPolygon, _BaseGeometry]],
+        crs: CRS,
+        time_interval: Tuple[str, str],
+        data_collection: DataCollection,
+        tile_split_shape: Union[int, Tuple[int, int]] = 1,
+        config: Optional[SHConfig] = None,
+        **kwargs: Any,
+    ):
         """
         :param shape_list: A list of geometrical shapes describing the area of interest
-        :type shape_list: list(shapely.geometry.multipolygon.MultiPolygon or shapely.geometry.polygon.Polygon)
         :param crs: Coordinate reference system of the shapes in `shape_list`
-        :type crs: CRS
         :param time_interval: Interval with start and end date of the form YYYY-MM-DDThh:mm:ss or YYYY-MM-DD
-        :type time_interval: (str, str)
         :param data_collection: A satellite data collection
-        :type data_collection: DataCollection
         :param tile_split_shape: Parameter that describes the shape in which the satellite tile bounding boxes will be
             split. It can be a tuple of the form `(n, m)` which means the tile bounding boxes will be
             split into `n` columns and `m` rows. It can also be a single integer `n` which is the same
             as `(n, n)`.
-        :type split_shape: int or (int, int)
         :param config: A custom instance of config class to override parameters from the saved configuration.
-        :type config: SHConfig or None
         :param kwargs: Parameters that are propagated to the base `AreaSplitter` class
         """
-        super().__init__(shape_list, crs, **kwargs)
-
         self.time_interval = time_interval
         self.tile_split_shape = tile_split_shape
         self.data_collection = data_collection
@@ -373,11 +370,8 @@ class TileSplitter(AreaSplitter):
         self.catalog = SentinelHubCatalog(config=sh_config)
         super().__init__(shape_list, crs, **kwargs)
 
-        self._make_split()
-
-    def _make_split(self):
-        """This method makes the split"""
-        tile_dict = {}
+    def _make_split(self) -> Tuple[List[BBox], List[Dict[str, object]]]:
+        tile_dict: Dict[Tuple[Tuple[float, ...], str], Dict[str, Any]] = {}
 
         search_iterator = self.catalog.search(
             self.data_collection, time=self.time_interval, bbox=self.area_bbox, fields=self._CATALOG_FILTER
@@ -419,29 +413,31 @@ class TileSplitter(AreaSplitter):
 class CustomGridSplitter(AreaSplitter):
     """Splitting class which can split according to given custom collection of bounding boxes"""
 
-    def __init__(self, shape_list, crs, bbox_grid, bbox_split_shape=1, **kwargs):
+    def __init__(
+        self,
+        shape_list: Iterable[Union[Polygon, MultiPolygon, _BaseGeometry]],
+        crs: CRS,
+        bbox_grid: Union[List[BBox], BBoxCollection],
+        bbox_split_shape: Union[int, Tuple[int, int]] = 1,
+        **kwargs: Any,
+    ):
         """
         :param shape_list: A list of geometrical shapes describing the area of interest
-        :type shape_list: list(shapely.geometry.multipolygon.MultiPolygon or shapely.geometry.polygon.Polygon)
         :param crs: Coordinate reference system of the shapes in `shape_list`
-        :type crs: CRS
         :param bbox_grid: A collection of bounding boxes defining a grid of splitting. All of them have to be in the
             same CRS.
-        :type bbox_grid: list(BBox) or BBoxCollection
         :param bbox_split_shape: Parameter that describes the shape in which each of the bounding boxes in the given
             grid will be split. It can be a tuple of the form `(n, m)` which means the tile bounding boxes will be
             split into `n` columns and `m` rows. It can also be a single integer `n` which is the same as `(n, n)`.
-        :type bbox_split_shape: int or (int, int)
         :param reduce_bbox_sizes: If `True` it will reduce the sizes of bounding boxes so that they will tightly fit
             the given geometry in `shape_list`.
-        :type reduce_bbox_sizes: bool
         """
         self.bbox_grid = self._parse_bbox_grid(bbox_grid)
         self.bbox_split_shape = bbox_split_shape
         super().__init__(shape_list, crs, **kwargs)
 
     @staticmethod
-    def _parse_bbox_grid(bbox_grid):
+    def _parse_bbox_grid(bbox_grid: Union[List[BBox], BBoxCollection]) -> BBoxCollection:
         """Helper method for parsing bounding box grid. It will try to parse it into `BBoxCollection`"""
         if isinstance(bbox_grid, BBoxCollection):
             return bbox_grid
@@ -451,6 +447,7 @@ class CustomGridSplitter(AreaSplitter):
 
         raise ValueError(f"Parameter 'bbox_grid' should be an instance of {BBoxCollection}")
 
+    def _make_split(self) -> Tuple[List[BBox], List[Dict[str, object]]]:
         bbox_list: List[BBox] = []
         info_list: List[Dict[str, object]] = []
 
@@ -476,17 +473,19 @@ class BaseUtmSplitter(AreaSplitter):
     `(N * bbox_size_x + offset_x, M * bbox_size_y + offset_y)`
     """
 
-    def __init__(self, shape_list, crs, bbox_size, offset=None):
+    def __init__(
+        self,
+        shape_list: Iterable[Union[Polygon, MultiPolygon, _BaseGeometry]],
+        crs: CRS,
+        bbox_size: Union[float, Tuple[float, float]],
+        offset: Union[None, Tuple[float, float]] = None,
+    ):
         """
         :param shape_list: A list of geometrical shapes describing the area of interest
-        :type shape_list: list(shapely.geometry.multipolygon.MultiPolygon or shapely.geometry.polygon.Polygon)
         :param crs: Coordinate reference system of the shapes in `shape_list`
-        :type crs: CRS
         :param bbox_size: A size of generated bounding boxes in horizontal and vertical directions in meters. If a
             single value is given that will be interpreted as (value, value).
-        :type bbox_size: int or (int, int) or float or (float, float)
         :param offset: Bounding box offset in horizontal and vertical directions in meters.
-        :type offset: (int, int) or (float, float) or None
         """
         self.bbox_size = self._parse_split_parameters(bbox_size)
         self.offset = self._parse_offset(offset)
@@ -511,7 +510,7 @@ class BaseUtmSplitter(AreaSplitter):
         )
 
     @staticmethod
-    def _parse_offset(offset_input):
+    def _parse_offset(offset_input: Union[None, Tuple[float, float]]) -> Tuple[float, float]:
         """Validates and parses offset input"""
         if offset_input is None:
             return 0, 0
@@ -523,29 +522,25 @@ class BaseUtmSplitter(AreaSplitter):
         raise ValueError(f"An offset parameter should be a tuple of two numbers, instead {offset_input} was given")
 
     @abstractmethod
-    def _get_utm_polygons(self):
+    def _get_utm_polygons(self) -> List[Tuple[BaseGeometry, Dict[str, Any]]]:
         raise NotImplementedError
 
     @staticmethod
-    def _get_utm_from_props(utm_dict):
+    def _get_utm_from_props(utm_dict: Dict[str, Any]) -> CRS:
         """Return the UTM CRS corresponding to the UTM described by the properties dictionary
 
         :param utm_dict: Dictionary reporting name of the UTM zone and MGRS grid
-        :type utm_dict: dict
         :return: UTM coordinate reference system
-        :rtype: sentinelhub.CRS
         """
         hemisphere_digit = 6 if utm_dict["direction"] == "N" else 7
         zone_number = utm_dict["zone"]
         return CRS(f"32{hemisphere_digit}{zone_number:02d}")
 
-    def _align_bbox_to_size(self, bbox):
+    def _align_bbox_to_size(self, bbox: BBox) -> BBox:
         """Align input bbox coordinates to be multiples of the bbox size
 
         :param bbox: Bounding box in UTM coordinates
-        :type bbox: sentinelhub.BBox
         :return: BBox objects with coordinates multiples of the bbox size
-        :rtype: sentinelhub.BBox
         """
         size_x, size_y = self.bbox_size
         offset_x, offset_y = self.offset
@@ -556,7 +551,7 @@ class BaseUtmSplitter(AreaSplitter):
 
         return BBox(((aligned_x, aligned_y), bbox.upper_right), crs=bbox.crs)
 
-    def _make_split(self):
+    def _make_split(self) -> Tuple[List[BBox], List[Dict[str, object]]]:
         """Split each UTM grid into equally sized bboxes in correct UTM zone"""
         size_x, size_y = self.bbox_size
         bbox_list: List[BBox] = []
@@ -602,16 +597,14 @@ class BaseUtmSplitter(AreaSplitter):
                         index += 1
         return bbox_list, info_list
 
-    def get_bbox_list(self, buffer=None):
+    def get_bbox_list(self, buffer: Union[None, float, Tuple[float, float]] = None) -> List[BBox]:  # type: ignore
         """Get list of bounding boxes.
 
         The CRS is fixed to the computed UTM CRS. This BBox splitter does not support reducing size of output
         bounding boxes
 
         :param buffer: A percentage of each BBox size increase. This will cause neighbouring bounding boxes to overlap.
-        :type buffer: (float, float) or float or None
         :return: List of bounding boxes
-        :rtype: list(BBox)
         """
         return super().get_bbox_list(buffer=buffer)
 
@@ -619,11 +612,10 @@ class BaseUtmSplitter(AreaSplitter):
 class UtmGridSplitter(BaseUtmSplitter):
     """Splitter that returns bounding boxes of fixed size aligned to the UTM MGRS grid"""
 
-    def _get_utm_polygons(self):
+    def _get_utm_polygons(self) -> List[Tuple[BaseGeometry, Dict[str, Any]]]:
         """Find UTM grid zones overlapping with input area shape
 
         :return: List of geometries and properties of UTM grid zones overlapping with input area shape
-        :rtype: list
         """
         # file downloaded from faculty.baruch.cuny.edu/geoportal/data/esri/world/utmzone.zip
         utm_grid_filename = os.path.join(os.path.dirname(__file__), ".utmzones.geojson")
@@ -653,13 +645,12 @@ class UtmZoneSplitter(BaseUtmSplitter):
     LNG_MIN, LNG_MAX, LNG_UTM = -180, 180, 6
     LAT_MIN, LAT_MAX, LAT_EQ = -80, 84, 0
 
-    def _get_utm_polygons(self):
+    def _get_utm_polygons(self) -> List[Tuple[BaseGeometry, Dict[str, Any]]]:
         """Find UTM zones overlapping with input area shape
 
         The returned geometry corresponds to a triangle ranging from the equator to the North/South Pole
 
         :return: List of geometries and properties of UTM zones overlapping with input area shape
-        :rtype: list
         """
         utm_geom_list = []
         for lat in [(self.LAT_EQ, self.LAT_MAX), (self.LAT_MIN, self.LAT_EQ)]:
@@ -688,15 +679,18 @@ class UtmZoneSplitter(BaseUtmSplitter):
 class BatchSplitter(AreaSplitter):
     """A splitter that obtains split bounding boxes from Sentinel Hub Batch API"""
 
-    def __init__(self, *, request_id=None, batch_request=None, config=None):
+    def __init__(
+        self,
+        *,
+        request_id: Optional[str] = None,
+        batch_request: Optional[BatchRequest] = None,
+        config: Optional[SHConfig] = None,
+    ):
         """
         :param request_id: An ID of a batch request
-        :type request_id: str or None
         :param batch_request: A batch request object. It is an alternative to the `request_id` parameter
-        :type batch_request: BatchRequest or None
         :param config: A configuration object with credentials and information about which service deployment to
             use.
-        :type config: SHConfig or None
         """
         self.batch_client = SentinelHubBatch(config=config)
 
@@ -710,9 +704,7 @@ class BatchSplitter(AreaSplitter):
         batch_geometry = batch_request.geometry
         super().__init__([batch_geometry.geometry], batch_geometry.crs)
 
-
-
-    def _make_split(self):
+    def _make_split(self) -> Tuple[List[BBox], List[Dict[str, object]]]:
         """This method actually loads bounding boxes from the service and prepares the lists"""
         tile_info_list = list(self.batch_client.iter_tiles(self.batch_request))
 

--- a/sentinelhub/areas.py
+++ b/sentinelhub/areas.py
@@ -42,26 +42,12 @@ class AreaSplitter(metaclass=ABCMeta):
             the given geometry in `shape_list`.
         """
         self.crs = CRS(crs)
-        self.shape_list = self._parse_shape_list(shape_list, self.crs)
+        self.shape_list = [self._parse_shape(shape, crs) for shape in shape_list]
         self.area_shape = self._join_shape_list(self.shape_list)
         self.reduce_bbox_sizes = reduce_bbox_sizes
 
         self.area_bbox = self.get_area_bbox()
         self.bbox_list, self.info_list = self._make_split()
-
-    @staticmethod
-    def _parse_shape_list(
-        shape_list: Iterable[Union[Polygon, MultiPolygon, _BaseGeometry]], crs: CRS
-    ) -> List[Union[Polygon, MultiPolygon]]:
-        """Checks if the given list of shapes is in correct format and parses geometry objects
-
-        :param shape_list: The parameter `shape_list` from class initialization
-        :raises: ValueError
-        """
-        if not isinstance(shape_list, list):
-            raise ValueError("Splitter must be initialized with a list of shapes")
-
-        return [AreaSplitter._parse_shape(shape, crs) for shape in shape_list]
 
     @staticmethod
     def _parse_shape(shape: Union[Polygon, MultiPolygon, _BaseGeometry], crs: CRS) -> Union[Polygon, MultiPolygon]:

--- a/sentinelhub/geometry.py
+++ b/sentinelhub/geometry.py
@@ -3,7 +3,7 @@ Module implementing geometry classes
 """
 from abc import ABCMeta, abstractmethod
 from math import ceil
-from typing import Iterator, List, Optional, Tuple, Union
+from typing import Iterator, List, Optional, Tuple, TypeVar, Union
 
 import shapely.geometry
 import shapely.ops
@@ -13,6 +13,8 @@ from shapely.geometry.base import BaseGeometry
 
 from .constants import CRS
 from .geo_utils import transform_point
+
+Self = TypeVar("Self", bound="_BaseGeometry")
 
 
 class _BaseGeometry(metaclass=ABCMeta):
@@ -68,6 +70,10 @@ class _BaseGeometry(metaclass=ABCMeta):
         :return: string in WKT format
         """
         return self.geometry.wkt
+
+    @abstractmethod
+    def transform(self: Self, crs: CRS, always_xy: bool = True) -> Self:
+        """Transforms geometry from current CRS to target CRS."""
 
 
 class BBox(_BaseGeometry):


### PR DESCRIPTION
The MR comes in three commits, and I suggest it is best reviewed this way.
1. Change of `_make_split` so that it is now part of the super class, where all subclasses first set any attributes and then call `super().__init__`. This is a *90% there* improvement, because a 100% would need metaclasses and we don't want that. The method also now returns lists, instead of modifying attributes (risky)
2. Add type annotations. `UtmSplitter`s need a `type: ignore` because they redefine the interface of `get_bbox_list`.
3. Some more refactorings.


There are three similar functions for `_parse_split_parameters` that could be unified with some advanced `overload` use, I can try and do that if you feel it is necessary