### PR TITLE
Suggestion: Refactor Config class

### DIFF
--- a/sentinelhub/config.py
+++ b/sentinelhub/config.py
@@ -130,9 +130,9 @@ class SHConfig:  # pylint: disable=too-many-instance-attributes
                 continue
             if not isinstance(value, param_type):
                 raise ValueError(f"Value of parameter '{param}' must be of type {param_type.__name__}")
-        if self["max_wfs_records_per_query"] > 100:  # type: ignore[operator]
+        if self.max_wfs_records_per_query > 100:
             raise ValueError("Value of config parameter 'max_wfs_records_per_query' must be at most 100")
-        if self["max_opensearch_records_per_query"] > 500:  # type: ignore[operator]
+        if self.max_opensearch_records_per_query > 500:
             raise ValueError("Value of config parameter 'max_opensearch_records_per_query' must be at most 500")
 
     def __getitem__(self, name: str) -> Union[str, int, float]:

--- a/sentinelhub/config.py
+++ b/sentinelhub/config.py
@@ -11,121 +11,7 @@ from typing import Any, Dict, Iterable, List, Optional, Union
 ConfigDict = Dict[str, Union[str, int, float]]
 
 
-class _BaseSHConfig:
-    """A base class for the sentinelhub-py package configuration class.
-
-    Only contains defaults and custom getter methods.
-    """
-
-    CREDENTIALS = {
-        "instance_id",
-        "sh_client_id",
-        "sh_client_secret",
-        "aws_access_key_id",
-        "aws_secret_access_key",
-        "aws_session_token",
-    }
-    CONFIG_PARAMS = [
-        "instance_id",
-        "sh_client_id",
-        "sh_client_secret",
-        "sh_base_url",
-        "sh_auth_base_url",
-        "geopedia_wms_url",
-        "geopedia_rest_url",
-        "aws_access_key_id",
-        "aws_secret_access_key",
-        "aws_session_token",
-        "aws_metadata_url",
-        "aws_s3_l1c_bucket",
-        "aws_s3_l2a_bucket",
-        "opensearch_url",
-        "max_wfs_records_per_query",
-        "max_opensearch_records_per_query",
-        "max_download_attempts",
-        "download_sleep_time",
-        "download_timeout_seconds",
-        "number_of_download_processes",
-    ]
-
-    def __init__(self) -> None:
-        self.instance_id: str = ""
-        self.sh_client_id: str = ""
-        self.sh_client_secret: str = ""
-        self.sh_base_url: str = "https://services.sentinel-hub.com"
-        self.sh_auth_base_url: str = "https://services.sentinel-hub.com"
-        self.geopedia_wms_url: str = "https://service.geopedia.world"
-        self.geopedia_rest_url: str = "https://www.geopedia.world/rest"
-        self.aws_access_key_id: str = ""
-        self.aws_secret_access_key: str = ""
-        self.aws_session_token: str = ""
-        self.aws_metadata_url: str = "https://roda.sentinel-hub.com"
-        self.aws_s3_l1c_bucket: str = "sentinel-s2-l1c"
-        self.aws_s3_l2a_bucket: str = "sentinel-s2-l2a"
-        self.opensearch_url: str = "http://opensearch.sentinel-hub.com/resto/api/collections/Sentinel2"
-        self.max_wfs_records_per_query: int = 100
-        self.max_opensearch_records_per_query: int = 500  # pylint: disable=invalid-name
-        self.max_download_attempts: int = 4
-        self.download_sleep_time: float = 5.0
-        self.download_timeout_seconds: float = 120.0
-        self.number_of_download_processes: int = 1
-
-    def __getitem__(self, name: str) -> Union[str, int, float]:
-        """Config parameters can also be accessed as items."""
-        if name in self.CONFIG_PARAMS:
-            return getattr(self, name)
-        raise KeyError(f"'{name}' is not a supported config parameter")
-
-    def has_eocloud_url(self) -> bool:
-        """Checks if base Sentinel Hub URL is set to eocloud URL
-
-        :return: `True` if 'eocloud' string is in base OGC URL else `False`
-        """
-        return "eocloud" in self.sh_base_url
-
-    def get_sh_oauth_url(self) -> str:
-        """Provides URL for Sentinel Hub authentication endpoint
-
-        :return: A URL endpoint
-        """
-        return f"{self.sh_auth_base_url}/oauth/token"
-
-    def get_sh_process_api_url(self) -> str:
-        """Provides URL for Sentinel Hub Process API endpoint
-
-        :return: A URL endpoint
-        """
-        return f"{self.sh_base_url}/api/v1/process"
-
-    def get_sh_ogc_url(self) -> str:
-        """Provides URL for Sentinel Hub OGC endpoint
-
-        :return: A URL endpoint
-        """
-        ogc_endpoint = "v1" if self.has_eocloud_url() else "ogc"
-        return f"{self.sh_base_url}/{ogc_endpoint}"
-
-    def get_sh_rate_limit_url(self) -> str:
-        """Provides URL for Sentinel Hub rate limiting endpoint
-
-        :return: A URL endpoint
-        """
-        return f"{self.sh_auth_base_url}/aux/ratelimit"
-
-    def raise_for_missing_instance_id(self) -> None:
-        """In case Sentinel Hub instance ID is missing it raises an informative error
-
-        :raises: ValueError
-        """
-        if not self.instance_id:
-            raise ValueError(
-                "Sentinel Hub instance ID is missing. "
-                "Either provide it with SHConfig object or save it into config.json configuration file. "
-                "Check https://sentinelhub-py.readthedocs.io/en/latest/configure.html for more info."
-            )
-
-
-class SHConfig(_BaseSHConfig):
+class SHConfig:  # pylint: disable=too-many-instance-attributes
     """A sentinelhub-py package configuration class.
 
     The class reads during its first initialization the configurable settings from ``./config.json`` file:
@@ -162,6 +48,37 @@ class SHConfig(_BaseSHConfig):
 
     """
 
+    CREDENTIALS = {
+        "instance_id",
+        "sh_client_id",
+        "sh_client_secret",
+        "aws_access_key_id",
+        "aws_secret_access_key",
+        "aws_session_token",
+    }
+    CONFIG_PARAMS = [
+        "instance_id",
+        "sh_client_id",
+        "sh_client_secret",
+        "sh_base_url",
+        "sh_auth_base_url",
+        "geopedia_wms_url",
+        "geopedia_rest_url",
+        "aws_access_key_id",
+        "aws_secret_access_key",
+        "aws_session_token",
+        "aws_metadata_url",
+        "aws_s3_l1c_bucket",
+        "aws_s3_l2a_bucket",
+        "opensearch_url",
+        "max_wfs_records_per_query",
+        "max_opensearch_records_per_query",
+        "max_download_attempts",
+        "download_sleep_time",
+        "download_timeout_seconds",
+        "number_of_download_processes",
+    ]
+
     _cache: Optional[Dict[str, Any]] = None
 
     def __init__(self, hide_credentials: bool = False, use_defaults: bool = False):
@@ -171,21 +88,37 @@ class SHConfig(_BaseSHConfig):
             default is `False`.
         :param use_defaults: Does not load the configuration file, returns config object with defaults only.
         """
-        super().__init__()
+
+        self.instance_id: str = ""
+        self.sh_client_id: str = ""
+        self.sh_client_secret: str = ""
+        self.sh_base_url: str = "https://services.sentinel-hub.com"
+        self.sh_auth_base_url: str = "https://services.sentinel-hub.com"
+        self.geopedia_wms_url: str = "https://service.geopedia.world"
+        self.geopedia_rest_url: str = "https://www.geopedia.world/rest"
+        self.aws_access_key_id: str = ""
+        self.aws_secret_access_key: str = ""
+        self.aws_session_token: str = ""
+        self.aws_metadata_url: str = "https://roda.sentinel-hub.com"
+        self.aws_s3_l1c_bucket: str = "sentinel-s2-l1c"
+        self.aws_s3_l2a_bucket: str = "sentinel-s2-l2a"
+        self.opensearch_url: str = "http://opensearch.sentinel-hub.com/resto/api/collections/Sentinel2"
+        self.max_wfs_records_per_query: int = 100
+        self.max_opensearch_records_per_query: int = 500  # pylint: disable=invalid-name
+        self.max_download_attempts: int = 4
+        self.download_sleep_time: float = 5.0
+        self.download_timeout_seconds: float = 120.0
+        self.number_of_download_processes: int = 1
+
         self._hide_credentials = hide_credentials
 
         if not use_defaults:
             for param, value in self._global_cache.items():
                 setattr(self, param, value)
 
-    def _copy_values_from(self, other: "_BaseSHConfig") -> None:
-        """Copies values of CONFIG_PARAMS from other config instance."""
-        for param in self.CONFIG_PARAMS:
-            setattr(self, param, getattr(other, param))
-
     def _validate_values(self) -> None:
         """Ensures that the values are aligned with expectations."""
-        default = _BaseSHConfig()
+        default = SHConfig(use_defaults=True)
         for param in self.CONFIG_PARAMS:
             value = getattr(self, param)
             default_value = getattr(default, param)
@@ -201,6 +134,12 @@ class SHConfig(_BaseSHConfig):
             raise ValueError("Value of config parameter 'max_wfs_records_per_query' must be at most 100")
         if self["max_opensearch_records_per_query"] > 500:  # type: ignore[operator]
             raise ValueError("Value of config parameter 'max_opensearch_records_per_query' must be at most 500")
+
+    def __getitem__(self, name: str) -> Union[str, int, float]:
+        """Config parameters can also be accessed as items."""
+        if name in self.CONFIG_PARAMS:
+            return getattr(self, name)
+        raise KeyError(f"'{name}' is not a supported config parameter")
 
     def __str__(self) -> str:
         """Content of SHConfig in json schema. If `hide_credentials` is set to `True` then credentials will be
@@ -279,7 +218,7 @@ class SHConfig(_BaseSHConfig):
             ``['instance_id', 'aws_access_key_id', 'aws_secret_access_key']``, or as a single name, e.g.
             ``'sh_base_url'``. By default, all parameters will be reset and default value is ``Ellipsis``.
         """
-        default = _BaseSHConfig()
+        default = SHConfig(use_defaults=True)
 
         if params is ...:
             params = self.get_params()
@@ -293,7 +232,7 @@ class SHConfig(_BaseSHConfig):
                 f"Parameters must be specified in form of a list of strings or as a single string, instead got {params}"
             )
 
-    def _reset_param(self, param: str, default: _BaseSHConfig) -> None:
+    def _reset_param(self, param: str, default: "SHConfig") -> None:
         """Resets a single parameter
 
         :param param: A configuration parameter
@@ -346,3 +285,51 @@ class SHConfig(_BaseSHConfig):
 
         hide_size = min(max(len(value) - 4, 10), len(value))
         return "*" * hide_size + value[hide_size:]
+
+    def has_eocloud_url(self) -> bool:
+        """Checks if base Sentinel Hub URL is set to eocloud URL
+
+        :return: `True` if 'eocloud' string is in base OGC URL else `False`
+        """
+        return "eocloud" in self.sh_base_url
+
+    def get_sh_oauth_url(self) -> str:
+        """Provides URL for Sentinel Hub authentication endpoint
+
+        :return: A URL endpoint
+        """
+        return f"{self.sh_auth_base_url}/oauth/token"
+
+    def get_sh_process_api_url(self) -> str:
+        """Provides URL for Sentinel Hub Process API endpoint
+
+        :return: A URL endpoint
+        """
+        return f"{self.sh_base_url}/api/v1/process"
+
+    def get_sh_ogc_url(self) -> str:
+        """Provides URL for Sentinel Hub OGC endpoint
+
+        :return: A URL endpoint
+        """
+        ogc_endpoint = "v1" if self.has_eocloud_url() else "ogc"
+        return f"{self.sh_base_url}/{ogc_endpoint}"
+
+    def get_sh_rate_limit_url(self) -> str:
+        """Provides URL for Sentinel Hub rate limiting endpoint
+
+        :return: A URL endpoint
+        """
+        return f"{self.sh_auth_base_url}/aux/ratelimit"
+
+    def raise_for_missing_instance_id(self) -> None:
+        """In case Sentinel Hub instance ID is missing it raises an informative error
+
+        :raises: ValueError
+        """
+        if not self.instance_id:
+            raise ValueError(
+                "Sentinel Hub instance ID is missing. "
+                "Either provide it with SHConfig object or save it into config.json configuration file. "
+                "Check https://sentinelhub-py.readthedocs.io/en/latest/configure.html for more info."
+            )

--- a/sentinelhub/config.py
+++ b/sentinelhub/config.py
@@ -8,7 +8,6 @@ import numbers
 import os
 from typing import Dict, List, Optional, Union
 
-
 ConfigDict = Dict[str, Union[str, int, float]]
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -40,6 +40,7 @@ def test_config_file():
 
 def test_reset():
     config = SHConfig()
+    default_config = SHConfig(no_loading=True)
 
     old_value = config.instance_id
     new_value = "new"
@@ -53,7 +54,7 @@ def test_reset():
     assert config.instance_id == new_value, "Instance ID should not reset yet"
 
     config.reset()
-    assert config.instance_id == config._instance.CONFIG_PARAMS["instance_id"], "Instance ID should reset"
+    assert config.instance_id == default_config.instance_id, "Instance ID should reset"
 
 
 def test_save(restore_config):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -29,7 +29,7 @@ def test_config_file():
         config_dict = json.load(fp)
 
     for param, value in config_dict.items():
-        if param in config._instance.CREDENTIALS:
+        if param in config.CREDENTIALS:
             continue
 
         if isinstance(value, str):
@@ -40,14 +40,14 @@ def test_config_file():
 
 def test_reset():
     config = SHConfig()
-    default_config = SHConfig(no_loading=True)
+    default_config = SHConfig(use_defaults=True)
 
     old_value = config.instance_id
     new_value = "new"
     config.instance_id = new_value
     assert config.instance_id == new_value, "New value was not set"
     assert config["instance_id"] == new_value, "New value was not set"
-    assert config._instance.instance_id == old_value, "Private value has changed"
+    assert config._cache["instance_id"] == old_value, "Private value has changed"
 
     config.reset("sh_base_url")
     config.reset(["aws_access_key_id", "aws_secret_access_key"])
@@ -59,6 +59,7 @@ def test_reset():
 
 def test_save(restore_config):
     config = SHConfig()
+    old_value = config.download_timeout_seconds
 
     config.download_timeout_seconds = "abcd"
     with pytest.raises(ValueError):
@@ -66,6 +67,10 @@ def test_save(restore_config):
 
     new_value = 150.5
     config.download_timeout_seconds = new_value
+
+    new_config = SHConfig()
+    assert new_config.download_timeout_seconds == old_value, "Value should not have changed"
+
     config.save()
     config = SHConfig()
     assert config.download_timeout_seconds == new_value, "Saved value should have changed"
@@ -77,7 +82,7 @@ def test_copy():
 
     copied_config = config.copy()
     assert copied_config._hide_credentials
-    assert copied_config._instance is config._instance
+    assert copied_config._cache is config._cache
     assert copied_config.instance_id == config.instance_id
 
     copied_config.instance_id = "b"


### PR DESCRIPTION
While adding types to the Config class in the previous MR it looked to me like I could get rid of some python magic surrounding the Config class.

 I first flattened the internal class into the outer one. Later on I realized I can extract the *data-side* of the config and add the *magic-loading / credential-hiding* parts in a subclass. This should make it a bit easier to improve the class further.

I also added the functionality of saving to a custom path and loading from a custom path. These are just exposing the inner workings a bit, and I see no harm in adding them.