### PR TITLE
Session transfer, part 1

### DIFF
--- a/sentinelhub/api/base.py
+++ b/sentinelhub/api/base.py
@@ -20,7 +20,6 @@ from ..download.sentinelhub_client import SentinelHubDownloadClient
 from ..exceptions import MissingDataInRequestException, SHDeprecationWarning
 from .utils import datetime_config, remove_undefined
 
-
 if sys.version_info < (3, 8):
     from typing_extensions import Protocol
 else:

--- a/sentinelhub/download/sentinelhub_client.py
+++ b/sentinelhub/download/sentinelhub_client.py
@@ -177,3 +177,8 @@ class SentinelHubDownloadClient(DownloadClient):
             return sh_client_id, base_url
 
         raise ValueError(f"Expected a config or a session object but got {config_or_session}")
+
+    @staticmethod
+    def clear_cache() -> None:
+        """Clears cached sessions."""
+        SentinelHubDownloadClient._CACHED_SESSIONS = {}

--- a/sentinelhub/download/session.py
+++ b/sentinelhub/download/session.py
@@ -5,7 +5,8 @@ import base64
 import json
 import logging
 import time
-from typing import Any, Dict, Optional
+import warnings
+from typing import Any, Dict, Optional, Union
 
 from oauthlib.oauth2 import BackendApplicationClient
 from requests_oauthlib import OAuth2Session
@@ -13,50 +14,82 @@ from requests_oauthlib import OAuth2Session
 from ..config import SHConfig
 from ..download.handlers import fail_user_errors, retry_temporary_errors
 from ..download.request import DownloadRequest
+from ..exceptions import SHUserWarning
 
 LOGGER = logging.getLogger(__name__)
+
+JsonDict = Dict[str, Any]
 
 
 class SentinelHubSession:
     """Sentinel Hub authentication class
 
-    The class will do OAuth2 authentication with Sentinel Hub service and store the token. It will make sure that the
-    token is never expired by automatically refreshing it if expiry time is close.
+    The class will do OAuth2 authentication with Sentinel Hub service and store the token. It is able to refresh the
+    token before it expires and decode user information from the token.
 
     For more info about Sentinel Hub authentication check
     `service documentation <https://docs.sentinel-hub.com/api/latest/api/overview/authentication/>`__.
     """
 
-    SECONDS_BEFORE_EXPIRY = 60
+    DEFAULT_SECONDS_BEFORE_EXPIRY = 60
 
-    def __init__(self, config: Optional[SHConfig] = None):
+    def __init__(
+        self,
+        config: Optional[SHConfig] = None,
+        refresh_before_expiry: Optional[Union[int, float]] = DEFAULT_SECONDS_BEFORE_EXPIRY,
+        _token: Optional[JsonDict] = None,
+    ):
         """
-        :param config: An instance of package configuration class
+        :param config: A config object containing Sentinel Hub OAuth credentials and the base URL of the service.
+        :param refresh_before_expiry: A number of seconds before authentication token expiry at which time a refreshing
+            mechanism is activated. When this is activated it means that whenever a valid token will be again
+            required the `SentinelHubSession` will re-authenticate to Sentinel Hub service and obtain a new token.
+            By default, the parameter is set to `60` seconds. If this parameter is set to `None` it will deactivate
+            token refreshing and `SentinelHubSession` might provide a token that is already expired. This can be is
+            used to avoid re-authenticating too many times.
         """
         self.config = config or SHConfig()
+        self.refresh_before_expiry = refresh_before_expiry
 
-        if not (self.config.sh_client_id and self.config.sh_client_secret):
+        token_fetching_required = _token is None or self.refresh_before_expiry is not None
+        if token_fetching_required and not (self.config.sh_client_id and self.config.sh_client_secret):
             raise ValueError(
                 "Configuration parameters 'sh_client_id' and 'sh_client_secret' have to be set in order "
                 "to authenticate with Sentinel Hub service. Check "
                 "https://sentinelhub-py.readthedocs.io/en/latest/configure.html for more info."
             )
 
-        self._token = self._collect_new_token()
+        self._token = self._collect_new_token() if _token is None else _token
+
+    @classmethod
+    def from_token(cls, token) -> "SentinelHubSession":
+        """Create a session object from the given token. The created session is configured not to refresh its token.
+
+        :param token: A dictionary containing token object.
+        """
+        for key in ["access_token", "expires_at"]:
+            if key not in token:
+                raise ValueError(f"Given token should be a dictionary containing a key '{key}'")
+
+        return cls(_token=token, refresh_before_expiry=None)
 
     @property
-    def token(self) -> Dict[str, Any]:
+    def token(self) -> JsonDict:
         """Always up-to-date session's token
 
         :return: A token in a form of dictionary of parameters
         """
-        if self._token and self._token["expires_at"] > time.time() + self.SECONDS_BEFORE_EXPIRY:
+        remaining_token_time = self._token["expires_at"] - time.time()
+        if self.refresh_before_expiry is None or remaining_token_time > self.refresh_before_expiry:
+            if remaining_token_time <= 0:
+                warnings.warn("The Sentinel Hub session token seems to be expired.", category=SHUserWarning)
+
             return self._token
 
         self._token = self._collect_new_token()
         return self._token
 
-    def info(self) -> Dict[str, Any]:
+    def info(self) -> JsonDict:
         """Decode token to get token info"""
 
         token = self.token["access_token"].split(".")[1]
@@ -72,7 +105,7 @@ class SentinelHubSession:
         """
         return {"Authorization": f'Bearer {self.token["access_token"]}'}
 
-    def _collect_new_token(self) -> Dict[str, Any]:
+    def _collect_new_token(self) -> JsonDict:
         """Creates a download request and fetches a token from the service.
 
         Note that the `DownloadRequest` object is created only because retry decorators of `_fetch_method` require it.
@@ -82,7 +115,7 @@ class SentinelHubSession:
 
     @retry_temporary_errors
     @fail_user_errors
-    def _fetch_token(self, request: DownloadRequest) -> Dict[str, Any]:
+    def _fetch_token(self, request: DownloadRequest) -> JsonDict:
         """Collects a new token from Sentinel Hub service"""
         oauth_client = BackendApplicationClient(client_id=self.config.sh_client_id)
 

--- a/sentinelhub/download/session.py
+++ b/sentinelhub/download/session.py
@@ -6,7 +6,7 @@ import json
 import logging
 import time
 import warnings
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, Optional
 
 from oauthlib.oauth2 import BackendApplicationClient
 from requests_oauthlib import OAuth2Session
@@ -36,7 +36,8 @@ class SentinelHubSession:
     def __init__(
         self,
         config: Optional[SHConfig] = None,
-        refresh_before_expiry: Optional[Union[int, float]] = DEFAULT_SECONDS_BEFORE_EXPIRY,
+        refresh_before_expiry: Optional[float] = DEFAULT_SECONDS_BEFORE_EXPIRY,
+        *,
         _token: Optional[JsonDict] = None,
     ):
         """
@@ -45,8 +46,8 @@ class SentinelHubSession:
             mechanism is activated. When this is activated it means that whenever a valid token will be again
             required the `SentinelHubSession` will re-authenticate to Sentinel Hub service and obtain a new token.
             By default, the parameter is set to `60` seconds. If this parameter is set to `None` it will deactivate
-            token refreshing and `SentinelHubSession` might provide a token that is already expired. This can be is
-            used to avoid re-authenticating too many times.
+            token refreshing and `SentinelHubSession` might provide a token that is already expired. This can be used
+            to avoid re-authenticating too many times.
         """
         self.config = config or SHConfig()
         self.refresh_before_expiry = refresh_before_expiry
@@ -108,7 +109,8 @@ class SentinelHubSession:
     def _collect_new_token(self) -> JsonDict:
         """Creates a download request and fetches a token from the service.
 
-        Note that the `DownloadRequest` object is created only because retry decorators of `_fetch_method` require it.
+        Note that the `DownloadRequest` object is created only because retry decorators of `_fetch_token` method
+        require it.
         """
         request = DownloadRequest(url=self.config.get_sh_oauth_url())
         return self._fetch_token(request)

--- a/sentinelhub/download/session.py
+++ b/sentinelhub/download/session.py
@@ -81,13 +81,14 @@ class SentinelHubSession:
         :return: A token in a form of dictionary of parameters
         """
         remaining_token_time = self._token["expires_at"] - time.time()
-        if self.refresh_before_expiry is None or remaining_token_time > self.refresh_before_expiry:
+        if self.refresh_before_expiry is None:
             if remaining_token_time <= 0:
                 warnings.warn("The Sentinel Hub session token seems to be expired.", category=SHUserWarning)
-
             return self._token
 
-        self._token = self._collect_new_token()
+        if remaining_token_time <= self.refresh_before_expiry:
+            self._token = self._collect_new_token()
+
         return self._token
 
     def info(self) -> JsonDict:

--- a/tests/api/test_process.py
+++ b/tests/api/test_process.py
@@ -436,14 +436,14 @@ def test_bad_credentials():
     )
 
     bad_credentials_config = SHConfig()
-    bad_credentials_config.sh_client_secret = "test-wrong-credentials"
+    bad_credentials_config.sh_client_id = "test"
 
     request = SentinelHubRequest(**request_params, config=bad_credentials_config)
     with pytest.raises(CustomOAuth2Error):
         request.get_data()
 
     missing_credentials_config = SHConfig()
-    missing_credentials_config.sh_client_secret = ""
+    missing_credentials_config.sh_client_id = ""
 
     request = SentinelHubRequest(**request_params, config=missing_credentials_config)
     with pytest.raises(ValueError):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ import shutil
 
 import pytest
 
-from sentinelhub import SHConfig
+from sentinelhub import SentinelHubSession, SHConfig
 
 pytest.register_assert_rewrite("sentinelhub.testing_utils")
 from sentinelhub.testing_utils import get_input_folder, get_output_folder
@@ -50,6 +50,11 @@ def logger_fixture():
         level=logging.INFO, format="%(asctime)-15s %(module)s:%(lineno)d [%(levelname)s] %(funcName)s  %(message)s"
     )
     return logging.getLogger(__name__)
+
+
+@pytest.fixture(name="session", scope="session")
+def session_fixture():
+    return SentinelHubSession()
 
 
 @pytest.fixture(name="ray")

--- a/tests/download/test_sentinelhub_client.py
+++ b/tests/download/test_sentinelhub_client.py
@@ -3,15 +3,9 @@ import pytest
 from sentinelhub import SentinelHubDownloadClient, SentinelHubStatisticalDownloadClient, SHConfig
 
 
-@pytest.fixture(name="blank_config")
-def blank_config_fixture():
-    config = SHConfig()
-    config.reset()
-    return config
-
-
 @pytest.mark.sh_integration
-def test_client_with_fixed_session(session, blank_config):
+def test_client_with_fixed_session(session):
+    blank_config = SHConfig(use_defaults=True)
     client = SentinelHubDownloadClient(session=session, config=blank_config)
 
     used_session = client.get_session()

--- a/tests/download/test_sentinelhub_client.py
+++ b/tests/download/test_sentinelhub_client.py
@@ -1,0 +1,51 @@
+import pytest
+
+from sentinelhub import SentinelHubDownloadClient, SentinelHubStatisticalDownloadClient, SHConfig
+
+
+@pytest.fixture(name="blank_config")
+def blank_config_fixture():
+    config = SHConfig()
+    config.reset()
+    return config
+
+
+@pytest.mark.sh_integration
+def test_client_with_fixed_session(session, blank_config):
+    client = SentinelHubDownloadClient(session=session, config=blank_config)
+
+    used_session = client.get_session()
+    assert used_session is session
+
+    info = client.get_json("https://services.sentinel-hub.com/oauth/tokeninfo", use_session=True)
+    assert info
+
+    with pytest.raises(ValueError):
+        SentinelHubDownloadClient(session=blank_config, config=blank_config)
+
+
+@pytest.mark.sh_integration
+@pytest.mark.parametrize("client_object", [SentinelHubDownloadClient, SentinelHubDownloadClient()])
+def test_session_caching_and_clearing(client_object, session):
+    client_object.clear_cache()
+    assert SentinelHubDownloadClient._CACHED_SESSIONS == {}
+
+    client_object.cache_session(session)
+    assert len(SentinelHubDownloadClient._CACHED_SESSIONS) == 1
+    assert list(SentinelHubDownloadClient._CACHED_SESSIONS.values()) == [session]
+
+    client_object.clear_cache()
+    assert SentinelHubDownloadClient._CACHED_SESSIONS == {}
+
+
+@pytest.mark.sh_integration
+def test_session_caching_on_subclass(session):
+    statistical_client = SentinelHubStatisticalDownloadClient()
+    statistical_client.cache_session(session)
+
+    assert len(SentinelHubDownloadClient._CACHED_SESSIONS) == 1
+    assert list(SentinelHubDownloadClient._CACHED_SESSIONS.values()) == [session]
+
+    client = SentinelHubDownloadClient()
+    used_session = client.get_session()
+    assert used_session is session

--- a/tests/download/test_session.py
+++ b/tests/download/test_session.py
@@ -7,12 +7,6 @@ from sentinelhub import SentinelHubSession, SHConfig
 from sentinelhub.exceptions import SHUserWarning
 
 
-@pytest.fixture(name="session", scope="module")
-def session_fixture():
-    session = SentinelHubSession()
-    return session
-
-
 @pytest.fixture(name="fake_token")
 def fake_token_fixture():
     return {"access_token": "x", "expires_in": 1000, "expires_at": time.time() + 1000}

--- a/tests/download/test_session.py
+++ b/tests/download/test_session.py
@@ -40,8 +40,7 @@ def test_token_info(session):
 
 
 def test_session_with_missing_credentials(fake_token):
-    config_without_credentials = SHConfig()
-    config_without_credentials.reset()
+    config_without_credentials = SHConfig(use_defaults=True)
 
     with pytest.raises(ValueError):
         SentinelHubSession(config=config_without_credentials)
@@ -49,6 +48,7 @@ def test_session_with_missing_credentials(fake_token):
     with pytest.raises(ValueError):
         SentinelHubSession(config=config_without_credentials, _token=fake_token)
 
+    # This succeeds because it receives and existing token and refreshing is deactivated
     session = SentinelHubSession(config=config_without_credentials, refresh_before_expiry=None, _token=fake_token)
     assert session.token == fake_token
 

--- a/tests/download/test_session.py
+++ b/tests/download/test_session.py
@@ -68,14 +68,13 @@ def test_from_token(fake_token):
 @pytest.mark.sh_integration
 def test_refreshing_procedure(fake_token):
     config = SHConfig()
-    config.reset()
     config.sh_client_id = "sh-py-test"
     config.sh_client_secret = "sh-py-test"
 
     fake_token["expires_at"] -= 500
 
     for expiry in [None, 400]:
-        session = SentinelHubSession(config=config, refresh_before_expiry=None, _token=fake_token)
+        session = SentinelHubSession(config=config, refresh_before_expiry=expiry, _token=fake_token)
         assert session.token == fake_token
 
     session = SentinelHubSession(config=config, refresh_before_expiry=500, _token=fake_token)

--- a/tests/download/test_session.py
+++ b/tests/download/test_session.py
@@ -1,12 +1,21 @@
-import pytest
+import time
 
-from sentinelhub import SentinelHubSession
+import pytest
+from oauthlib.oauth2.rfc6749.errors import CustomOAuth2Error
+
+from sentinelhub import SentinelHubSession, SHConfig
+from sentinelhub.exceptions import SHUserWarning
 
 
 @pytest.fixture(name="session", scope="module")
 def session_fixture():
     session = SentinelHubSession()
     return session
+
+
+@pytest.fixture(name="fake_token")
+def fake_token_fixture():
+    return {"access_token": "x", "expires_in": 1000, "expires_at": time.time() + 1000}
 
 
 @pytest.mark.sh_integration
@@ -34,3 +43,47 @@ def test_token_info(session):
 
     for key in ["sub", "aud", "jti", "exp", "name", "email", "sid", "org", "did", "aid", "d"]:
         assert key in info
+
+
+def test_session_with_missing_credentials(fake_token):
+    config_without_credentials = SHConfig()
+    config_without_credentials.reset()
+
+    with pytest.raises(ValueError):
+        SentinelHubSession(config=config_without_credentials)
+
+    with pytest.raises(ValueError):
+        SentinelHubSession(config=config_without_credentials, _token=fake_token)
+
+    session = SentinelHubSession(config=config_without_credentials, refresh_before_expiry=None, _token=fake_token)
+    assert session.token == fake_token
+
+
+def test_from_token(fake_token):
+    session = SentinelHubSession.from_token(fake_token)
+    assert session.token == fake_token
+    assert session.refresh_before_expiry is None
+
+    fake_token["expires_at"] -= 1000
+    session = SentinelHubSession.from_token(fake_token)
+    with pytest.warns(SHUserWarning):
+        expired_token = session.token
+    assert expired_token == fake_token
+
+
+@pytest.mark.sh_integration
+def test_refreshing_procedure(fake_token):
+    config = SHConfig()
+    config.reset()
+    config.sh_client_id = "sh-py-test"
+    config.sh_client_secret = "sh-py-test"
+
+    fake_token["expires_at"] -= 500
+
+    for expiry in [None, 400]:
+        session = SentinelHubSession(config=config, refresh_before_expiry=None, _token=fake_token)
+        assert session.token == fake_token
+
+    session = SentinelHubSession(config=config, refresh_before_expiry=500, _token=fake_token)
+    with pytest.raises(CustomOAuth2Error):
+        _ = session.token


### PR DESCRIPTION
For issues: https://github.com/sentinel-hub/sentinelhub-py/issues/267, https://github.com/sentinel-hub/sentinelhub-py/issues/146

This PR adds the following:
- support from initializing `SentinelHubSession` object purely with an existing token,
- better support for caching session objects into `SentinelHubDownloadClient`.

Remaining things to do:
- As a proof of concept, implement session transfer in `eo-grow` `DownloadPipeline` which currently also has an issue that too many sessions get created when running with a Ray cluster.
- Write a documentation page about the session transfer procedure.

This will be done in the next PR.