### PR TITLE
Improve handling of unclosed shared memory

### DIFF
--- a/examples/session_sharing.ipynb
+++ b/examples/session_sharing.ipynb
@@ -377,7 +377,7 @@
    "source": [
     "from concurrent.futures import ProcessPoolExecutor\n",
     "\n",
-    "from sentinelhub.download import SessionSharingThread, collect_shared_session\n",
+    "from sentinelhub.download import SessionSharing, collect_shared_session\n",
     "\n",
     "\n",
     "def remote_function(url: str, config: SHConfig) -> None:\n",
@@ -395,20 +395,14 @@
     "# This will create a session that will be shared with all workers\n",
     "session = SentinelHubSession(config)\n",
     "\n",
-    "thread = SessionSharingThread(session)\n",
-    "thread.start()  # Start sharing a session token in a new thread\n",
-    "\n",
-    "# try-finally makes sure that the thread is stopped even in case of an error during parallelization\n",
-    "try:\n",
+    "# For the duration of \"with\" statement this will run a thread that will share the given Sentinel Hub session\n",
+    "with SessionSharing(session):\n",
+    "    \n",
     "    # Run parallelization process\n",
     "    with ProcessPoolExecutor(max_workers=3) as executor:\n",
     "        futures = [executor.submit(remote_function, EXAMPLE_URL, config) for _ in range(10)]\n",
     "        for future in futures:\n",
-    "            future.result()\n",
-    "\n",
-    "finally:\n",
-    "    # Stop the thread or it will continue running\n",
-    "    thread.join()"
+    "            future.result()"
    ]
   },
   {

--- a/examples/session_sharing.ipynb
+++ b/examples/session_sharing.ipynb
@@ -397,7 +397,7 @@
     "\n",
     "# For the duration of \"with\" statement this will run a thread that will share the given Sentinel Hub session\n",
     "with SessionSharing(session):\n",
-    "    \n",
+    "\n",
     "    # Run parallelization process\n",
     "    with ProcessPoolExecutor(max_workers=3) as executor:\n",
     "        futures = [executor.submit(remote_function, EXAMPLE_URL, config) for _ in range(10)]\n",

--- a/sentinelhub/download/__init__.py
+++ b/sentinelhub/download/__init__.py
@@ -6,4 +6,4 @@ from .client import DownloadClient
 from .request import DownloadRequest
 from .sentinelhub_client import SentinelHubDownloadClient
 from .sentinelhub_statistical_client import SentinelHubStatisticalDownloadClient
-from .session import SentinelHubSession, SessionSharingThread, collect_shared_session
+from .session import SentinelHubSession, SessionSharing, SessionSharingThread, collect_shared_session

--- a/sentinelhub/download/session.py
+++ b/sentinelhub/download/session.py
@@ -305,7 +305,14 @@ def collect_shared_session(memory_name: str = _DEFAULT_SESSION_MEMORY_NAME) -> S
         match the one used in `SessionSharingThread`.
     :return: An instance of `SentinelHubSession` that contains the shared token but is not self-refreshing.
     """
-    memory = SharedMemory(name=memory_name)
+    try:
+        memory = SharedMemory(name=memory_name)
+    except FileNotFoundError as exception:
+        raise FileNotFoundError(
+            f"Couldn't obtain a shared session because a shared memory '{memory_name}' doesn't exist. Make sure that"
+            " you are running session sharing when calling this function"
+        ) from exception
+
     try:
         encoded_token = memory.buf.tobytes().rstrip(_NULL_MEMORY_VALUE)
     finally:

--- a/sentinelhub/download/session.py
+++ b/sentinelhub/download/session.py
@@ -281,7 +281,7 @@ class SessionSharing:
             # Run a parallelization process here
     """
 
-    def __init__(self, session: SentinelHubSession, **kwargs):
+    def __init__(self, session: SentinelHubSession, **kwargs: Any):
         """
         :param args: A Sentinel Hub session to be used for sharing its authentication token.
         :param kwargs: Keyword arguments to be propagated to `SessionSharingThread`.
@@ -292,7 +292,7 @@ class SessionSharing:
         """Starts running the session-sharing thread."""
         self.thread.start()
 
-    def __exit__(self, *_, **__) -> None:
+    def __exit__(self, *_: Any, **__: Any) -> None:
         """Closes the running session-sharing thread."""
         self.thread.join()
 

--- a/tests/download/test_session.py
+++ b/tests/download/test_session.py
@@ -121,3 +121,17 @@ def test_session_sharing_multiprocess(fake_token, fake_config, memory_name):
         assert all(collected_session.token == fake_token for collected_session in collected_sessions)
     finally:
         thread.join()
+
+
+def test_handling_of_unclosed_memory(fake_token, fake_config):
+    session = SentinelHubSession(config=fake_config, refresh_before_expiry=0, _token=fake_token)
+
+    thread1 = SessionSharingThread(session)
+    thread1.start()
+
+    thread2 = SessionSharingThread(session)
+    with pytest.warns(SHUserWarning):
+        thread2.start()
+
+    thread1.join()
+    thread2.join()

--- a/tests/download/test_session.py
+++ b/tests/download/test_session.py
@@ -5,7 +5,7 @@ import pytest
 from oauthlib.oauth2.rfc6749.errors import CustomOAuth2Error
 
 from sentinelhub import SentinelHubSession, SHConfig
-from sentinelhub.download import SessionSharingThread, collect_shared_session
+from sentinelhub.download import SessionSharing, SessionSharingThread, collect_shared_session
 from sentinelhub.exceptions import SHUserWarning
 
 
@@ -121,6 +121,24 @@ def test_session_sharing_multiprocess(fake_token, fake_config, memory_name):
         assert all(collected_session.token == fake_token for collected_session in collected_sessions)
     finally:
         thread.join()
+
+
+@pytest.mark.parametrize("memory_name", [None, "test-name"])
+def test_session_sharing_object(fake_token, fake_config, memory_name):
+    session = SentinelHubSession(config=fake_config, refresh_before_expiry=0, _token=fake_token)
+
+    kwargs = {} if memory_name is None else {"memory_name": memory_name}
+    manager = SessionSharing(session, name="thread name", **kwargs)
+
+    with pytest.raises(FileNotFoundError):
+        collect_shared_session(**kwargs)
+
+    with manager:
+        collected_session = collect_shared_session(**kwargs)
+        assert collected_session.token == fake_token
+
+    with pytest.raises(FileNotFoundError):
+        collect_shared_session(**kwargs)
 
 
 def test_handling_of_unclosed_memory(fake_token, fake_config):


### PR DESCRIPTION
This PR adds 2 improvements:

- `SessionSharingThread` itself is now able to handle unclosed shared memory and warn users about it.
- `SessionSharing` object that is a more user-friendly interface around `SessionSharingThread`.