### PR TITLE
Compliance hook for Sentinel Hub authentication

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ utm
 shapely
 pyproj>=2.2.0
 oauthlib
-requests_oauthlib
+requests-oauthlib>=1.0.0
 aenum>=2.1.4
 dataclasses-json
 tqdm

--- a/sentinelhub/download/sentinelhub_client.py
+++ b/sentinelhub/download/sentinelhub_client.py
@@ -8,6 +8,7 @@ from threading import Lock
 from typing import Any, Callable, Dict, Optional, Tuple, TypeVar, Union
 
 import requests
+from requests import Response
 
 from ..config import SHConfig
 from ..exceptions import SHRateLimitWarning, SHRuntimeWarning
@@ -63,7 +64,7 @@ class SentinelHubDownloadClient(DownloadClient):
 
     @retry_temporary_errors
     @fail_user_errors
-    def _execute_download(self, request: DownloadRequest) -> Any:
+    def _execute_download(self, request: DownloadRequest) -> bytes:
         """
         Executes the download with a single thread and uses a rate limit object, which is shared between all threads
         """
@@ -101,7 +102,7 @@ class SentinelHubDownloadClient(DownloadClient):
         with self.lock:
             return thread_unsafe_function(*args, **kwargs)
 
-    def _do_download(self, request: DownloadRequest) -> Any:
+    def _do_download(self, request: DownloadRequest) -> Response:
         """Runs the download"""
         if request.url is None:
             raise ValueError(f"Faulty request {request}, no URL specified.")

--- a/sentinelhub/download/sentinelhub_statistical_client.py
+++ b/sentinelhub/download/sentinelhub_statistical_client.py
@@ -100,7 +100,7 @@ class SentinelHubStatisticalDownloadClient(SentinelHubDownloadClient):
 
         return dict(zip(time_intervals, stat_info_responses))
 
-    def _execute_single_stat_download(self, request: DownloadRequest) -> Any:
+    def _execute_single_stat_download(self, request: DownloadRequest) -> JsonDict:
         """Makes sure a download for a single time interval is retried"""
         for retry_count in range(self.n_interval_retries):
             response = self._execute_download(request)

--- a/sentinelhub/download/session.py
+++ b/sentinelhub/download/session.py
@@ -149,7 +149,7 @@ class SentinelHubSession:
         without an error message. In such cases `requests_oauthlib` would raise a completely wrong error message. This
         hook makes sure that a correct error message is raised.
 
-        It is important that in case of 5xx errors always an error is raised so that authentication can be retried.
+        It is important that in case of 5xx errors an error is always raised so that authentication can be retried.
         But in case of 4xx errors where response contains an error message this method intentionally doesn't raise
         an error so that `oauthlib` can later raise a more descriptive error.
         """

--- a/tests/download/test_session.py
+++ b/tests/download/test_session.py
@@ -101,7 +101,11 @@ def test_refreshing_procedure(fake_token, fake_config):
     ],
 )
 def test_oauth_compliance_hook_4xx(
-    requests_mock: Mocker, status_code: int, response_payload: Optional[JsonDict], expected_exception: Type[Exception]
+    requests_mock: Mocker,
+    status_code: int,
+    response_payload: Optional[JsonDict],
+    expected_exception: Type[Exception],
+    fake_config: SHConfig,
 ):
     requests_mock.post(
         "https://services.sentinel-hub.com/oauth/token",
@@ -110,7 +114,7 @@ def test_oauth_compliance_hook_4xx(
     )
 
     with pytest.raises(expected_exception):
-        SentinelHubSession()
+        SentinelHubSession(config=fake_config)
     assert len(requests_mock.request_history) == 1
 
 
@@ -123,20 +127,21 @@ def test_oauth_compliance_hook_4xx(
         (None,),
     ],
 )
-def test_oauth_compliance_hook_5xx(requests_mock: Mocker, status_code: int, response_payload: Optional[JsonDict]):
+def test_oauth_compliance_hook_5xx(
+    requests_mock: Mocker, status_code: int, response_payload: Optional[JsonDict], fake_config: SHConfig
+):
     requests_mock.post(
         "https://services.sentinel-hub.com/oauth/token",
         json=response_payload,
         status_code=status_code,
     )
 
-    config = SHConfig()
-    config.max_download_attempts = 10
-    config.download_sleep_time = 0
+    fake_config.max_download_attempts = 10
+    fake_config.download_sleep_time = 0
 
     with pytest.raises(DownloadFailedException):
-        SentinelHubSession(config=config)
-    assert len(requests_mock.request_history) == config.max_download_attempts
+        SentinelHubSession(config=fake_config)
+    assert len(requests_mock.request_history) == fake_config.max_download_attempts
 
 
 @pytest.mark.parametrize("memory_name", [None, "test-name"])


### PR DESCRIPTION
Package `requests-oauthlib` doesn't check for status errors of a response obtained from Sentinel Hub authentication service. Because of that it can raise a misleading `MissingTokenError`.

This PR solves the issue by adding a compliance hook into the process which checks for a response status and makes sure the correct error is raised. It also adds units tests for it.