### PR TITLE
Proposed solution to fix error in line 16

### DIFF
--- a/sentinelhub/download/session.py
+++ b/sentinelhub/download/session.py
@@ -13,7 +13,7 @@ from typing import Any, Dict, Optional
 import requests
 from oauthlib.oauth2 import BackendApplicationClient
 from requests import Response
-from requests.exceptions import JSONDecodeError
+from json import JSONDecodeError
 from requests_oauthlib import OAuth2Session
 
 from ..config import SHConfig


### PR DESCRIPTION
Cannot import JSONDecodeError using "requests.exception" and using "json" solved the issue. This error could be related to this thread: https://stackoverflow.com/questions/15170676/cannot-import-jsondecodeerror

This error was shown in Ubuntu 20.04 and the proposed solution was also tested in Ubuntu 20.04.