### PR TITLE
Improved handling of CatchAll

### DIFF
--- a/sentinelhub/api/base.py
+++ b/sentinelhub/api/base.py
@@ -91,12 +91,12 @@ class BaseCollection:
 
     name: str
     s3_bucket: str
-    other_data: CatchAll
     additional_data: Optional[_AdditionalData]
     collection_id: Optional[str] = field(metadata=dataclass_config(field_name="id"), default=None)
     user_id: Optional[str] = None
     created: Optional[datetime] = field(metadata=datetime_config, default=None)
     no_data: Optional[Union[int, float]] = None
+    other_data: CatchAll = None
 
     def to_data_collection(self) -> DataCollection:
         """Returns a DataCollection enum for this collection"""

--- a/sentinelhub/api/base.py
+++ b/sentinelhub/api/base.py
@@ -96,7 +96,7 @@ class BaseCollection:
     user_id: Optional[str] = None
     created: Optional[datetime] = field(metadata=datetime_config, default=None)
     no_data: Optional[Union[int, float]] = None
-    other_data: CatchAll = None
+    other_data: CatchAll = field(default_factory=dict)
 
     def to_data_collection(self) -> DataCollection:
         """Returns a DataCollection enum for this collection"""

--- a/sentinelhub/api/batch/process.py
+++ b/sentinelhub/api/batch/process.py
@@ -506,7 +506,7 @@ class BatchRequest(BaseBatchRequest):  # pylint: disable=abstract-method
     user_action: Optional[BatchUserAction] = field(metadata=enum_config(BatchUserAction), default=None)
     user_action_updated: Optional[str] = field(metadata=datetime_config, default=None)
     error: Optional[str] = None
-    other_data: CatchAll = None
+    other_data: CatchAll = field(default_factory=dict)
 
     _REPR_PARAM_NAMES = (
         "request_id",
@@ -567,7 +567,7 @@ class BatchCollectionBatchData:
     """Dataclass to hold batch collection batchData part of the payload"""
 
     tiling_grid_id: Optional[int] = None
-    other_data: CatchAll = None
+    other_data: CatchAll = field(default_factory=dict)
 
 
 @dataclass_json(letter_case=LetterCase.CAMEL, undefined=Undefined.INCLUDE)
@@ -576,7 +576,7 @@ class BatchCollectionAdditionalData:
     """Dataclass to hold batch collection additionalData part of the payload"""
 
     bands: Optional[Dict[str, Any]] = None
-    other_data: CatchAll = None
+    other_data: CatchAll = field(default_factory=dict)
 
 
 class BatchCollection(BaseCollection):

--- a/sentinelhub/api/batch/process.py
+++ b/sentinelhub/api/batch/process.py
@@ -487,11 +487,13 @@ class SentinelHubBatch(BaseBatchClient):
 class BatchRequest(BaseBatchRequest):  # pylint: disable=abstract-method
     """A dataclass object that holds information about a batch request"""
 
+    # dataclass_json doesn't handle parameter inheritance correctly
+    # pylint: disable=duplicate-code
+
     request_id: str = field(metadata=dataclass_config(field_name="id"))
     process_request: dict
     tile_count: int
     status: BatchRequestStatus = field(metadata=enum_config(BatchRequestStatus))
-    other_data: CatchAll
     user_id: Optional[str] = None
     created: Optional[dt.datetime] = field(metadata=datetime_config, default=None)
     tiling_grid: dict = field(default_factory=dict)
@@ -504,6 +506,7 @@ class BatchRequest(BaseBatchRequest):  # pylint: disable=abstract-method
     user_action: Optional[BatchUserAction] = field(metadata=enum_config(BatchUserAction), default=None)
     user_action_updated: Optional[str] = field(metadata=datetime_config, default=None)
     error: Optional[str] = None
+    other_data: CatchAll = None
 
     _REPR_PARAM_NAMES = (
         "request_id",
@@ -563,8 +566,8 @@ class BatchRequest(BaseBatchRequest):  # pylint: disable=abstract-method
 class BatchCollectionBatchData:
     """Dataclass to hold batch collection batchData part of the payload"""
 
-    other_data: CatchAll
     tiling_grid_id: Optional[int] = None
+    other_data: CatchAll = None
 
 
 @dataclass_json(letter_case=LetterCase.CAMEL, undefined=Undefined.INCLUDE)
@@ -572,8 +575,8 @@ class BatchCollectionBatchData:
 class BatchCollectionAdditionalData:
     """Dataclass to hold batch collection additionalData part of the payload"""
 
-    other_data: CatchAll
     bands: Optional[Dict[str, Any]] = None
+    other_data: CatchAll = None
 
 
 class BatchCollection(BaseCollection):

--- a/sentinelhub/api/batch/statistical.py
+++ b/sentinelhub/api/batch/statistical.py
@@ -192,8 +192,10 @@ class SentinelHubBatchStatistical(BaseBatchClient["BatchStatisticalRequest"]):
 class BatchStatisticalRequest(BaseBatchRequest):  # pylint: disable=abstract-method
     """A dataclass object that holds information about a batch statistical request"""
 
+    # dataclass_json doesn't handle parameter inheritance correctly
+    # pylint: disable=duplicate-code
+
     request_id: str = field(metadata=dataclass_config(field_name="id"))
-    other_data: CatchAll
     completion_percentage: float
     request: dict
     status: BatchRequestStatus = field(metadata=enum_config(BatchRequestStatus))
@@ -203,6 +205,7 @@ class BatchStatisticalRequest(BaseBatchRequest):  # pylint: disable=abstract-met
     user_action: Optional[BatchUserAction] = field(metadata=enum_config(BatchUserAction), default=None)
     user_action_updated: Optional[str] = field(metadata=datetime_config, default=None)
     error: Optional[str] = None
+    other_data: CatchAll = None
 
     _REPR_PARAM_NAMES = (
         "request_id",

--- a/sentinelhub/api/batch/statistical.py
+++ b/sentinelhub/api/batch/statistical.py
@@ -205,7 +205,7 @@ class BatchStatisticalRequest(BaseBatchRequest):  # pylint: disable=abstract-met
     user_action: Optional[BatchUserAction] = field(metadata=enum_config(BatchUserAction), default=None)
     user_action_updated: Optional[str] = field(metadata=datetime_config, default=None)
     error: Optional[str] = None
-    other_data: CatchAll = None
+    other_data: CatchAll = field(default_factory=dict)
 
     _REPR_PARAM_NAMES = (
         "request_id",

--- a/sentinelhub/api/byoc.py
+++ b/sentinelhub/api/byoc.py
@@ -26,12 +26,12 @@ TileType = Union["ByocTile", dict, str]
 class ByocCollectionBand:
     """Dataclass to hold BYOC collection band specification"""
 
-    other_data: CatchAll
     source: Optional[str] = None
     band_index: Optional[int] = None
     bit_depth: int = 8
     sample_format: str = "UINT"
     no_data: Optional[float] = None
+    other_data: CatchAll = None
 
 
 @dataclass_json(letter_case=LetterCase.CAMEL, undefined=Undefined.INCLUDE)
@@ -39,10 +39,10 @@ class ByocCollectionBand:
 class ByocCollectionAdditionalData:
     """Dataclass to hold BYOC collection additional data"""
 
-    other_data: CatchAll
     bands: Optional[Dict[str, ByocCollectionBand]] = None
     max_meters_per_pixel: Optional[float] = None
     max_meters_per_pixel_override: Optional[float] = None
+    other_data: CatchAll = None
 
 
 @dataclass_json(letter_case=LetterCase.CAMEL, undefined=Undefined.INCLUDE)
@@ -59,7 +59,6 @@ class ByocTile:
     """Dataclass to hold BYOC tile data"""
 
     path: str
-    other_data: CatchAll
     status: Optional[str] = None
     tile_id: Optional[str] = field(metadata=dataclass_config(field_name="id"), default=None)
     tile_geometry: Optional[Geometry] = field(metadata=geometry_config, default=None)
@@ -67,6 +66,7 @@ class ByocTile:
     created: Optional[datetime] = field(metadata=datetime_config, default=None)
     sensing_time: Optional[datetime] = field(metadata=datetime_config, default=None)
     additional_data: Optional[dict] = None
+    other_data: CatchAll = None
 
 
 class SentinelHubBYOC(SentinelHubService):

--- a/sentinelhub/api/byoc.py
+++ b/sentinelhub/api/byoc.py
@@ -31,7 +31,7 @@ class ByocCollectionBand:
     bit_depth: int = 8
     sample_format: str = "UINT"
     no_data: Optional[float] = None
-    other_data: CatchAll = None
+    other_data: CatchAll = field(default_factory=dict)
 
 
 @dataclass_json(letter_case=LetterCase.CAMEL, undefined=Undefined.INCLUDE)
@@ -42,7 +42,7 @@ class ByocCollectionAdditionalData:
     bands: Optional[Dict[str, ByocCollectionBand]] = None
     max_meters_per_pixel: Optional[float] = None
     max_meters_per_pixel_override: Optional[float] = None
-    other_data: CatchAll = None
+    other_data: CatchAll = field(default_factory=dict)
 
 
 @dataclass_json(letter_case=LetterCase.CAMEL, undefined=Undefined.INCLUDE)
@@ -66,7 +66,7 @@ class ByocTile:
     created: Optional[datetime] = field(metadata=datetime_config, default=None)
     sensing_time: Optional[datetime] = field(metadata=datetime_config, default=None)
     additional_data: Optional[dict] = None
-    other_data: CatchAll = None
+    other_data: CatchAll = field(default_factory=dict)
 
 
 class SentinelHubBYOC(SentinelHubService):

--- a/tests/api/test_byoc.py
+++ b/tests/api/test_byoc.py
@@ -131,6 +131,26 @@ def test_get_tile(byoc, collection, tile):
     assert ByocTile.from_dict(sh_tile) == ByocTile.from_dict(tile)
 
 
+def test_byoc_tile_generating():
+    """Makes sure all default parameters get defined in the same way."""
+    tile_from_init = ByocTile(path="x")
+    tile_from_dict = ByocTile.from_dict({"path": "x"})
+
+    assert tile_from_init == tile_from_dict
+
+
+def test_byoc_tile_other_data(tile):
+    """Makes sure other_data is handled correctly."""
+    tile["FakeParam"] = "x"
+
+    tile_object = ByocTile.from_dict(tile)
+    assert isinstance(tile_object, ByocTile)
+    assert tile_object.other_data == {"FakeParam": "x"}
+
+    tile_dict = tile_object.to_dict()
+    assert tile == tile_dict
+
+
 def test_create_collection(byoc, requests_mock):
     requests_mock.post("/oauth/token", real_http=True)
     mocked_url = "/api/v1/byoc/collections"


### PR DESCRIPTION
In the previous version both mypy and PyCharm were complaining about `other_data` parameter not being specified if someone tried to initialize an instance of a dataclass decorated with `@dataclass_json`.

This was solved by specifying the default value for this field and the only correct default values turned out to be `field(default_factory=dict)`.