### PR TITLE
Dependency handling to support QGIS plugin

### DIFF
--- a/sentinelhub/decoding.py
+++ b/sentinelhub/decoding.py
@@ -11,12 +11,20 @@ from typing import Any, Dict, Union
 from xml.etree import ElementTree
 
 import numpy as np
-import tifffile as tiff
-from PIL import Image
 from requests import Response
 
 from .constants import MimeType
-from .exceptions import ImageDecodingError
+from .exceptions import ImageDecodingError, show_import_warning
+
+# The following is only for the purpose of using the package within SentinelHub QGIS plugin
+try:  # pylint: disable=duplicate-code
+    import tifffile as tiff
+except ImportError:
+    show_import_warning("tifffile")
+try:
+    from PIL import Image
+except ImportError:
+    show_import_warning("Pillow")
 
 
 def decode_data(response_content: bytes, data_type: MimeType) -> Any:

--- a/sentinelhub/download/session.py
+++ b/sentinelhub/download/session.py
@@ -13,19 +13,25 @@ from typing import Any, Dict, Optional
 import requests
 from oauthlib.oauth2 import BackendApplicationClient
 from requests import Response
-from requests.exceptions import JSONDecodeError
 from requests_oauthlib import OAuth2Session
 
 from ..config import SHConfig
 from ..download.handlers import fail_user_errors, retry_temporary_errors
 from ..download.models import DownloadRequest
-from ..exceptions import SHUserWarning
+from ..exceptions import SHUserWarning, show_import_warning
 from ..type_utils import JsonDict
 
 if sys.version_info < (3, 8):
     from shared_memory import SharedMemory
 else:
     from multiprocessing.shared_memory import SharedMemory
+
+# The following is only for the purpose of using the package within SentinelHub QGIS plugin
+try:
+    from requests.exceptions import JSONDecodeError  # pylint: disable=ungrouped-imports
+except ImportError:
+    show_import_warning("requests>=2.27.0")
+    from json import JSONDecodeError  # type: ignore[misc]
 
 
 LOGGER = logging.getLogger(__name__)

--- a/sentinelhub/exceptions.py
+++ b/sentinelhub/exceptions.py
@@ -47,6 +47,11 @@ class SHUserWarning(UserWarning):
     """A custom user warning for sentinelhub-py package"""
 
 
+class SHImportWarning(SHUserWarning):
+    """A custom warning shown if a dependency package failed to be imported. This can happen in case the package was
+    installed without some dependencies."""
+
+
 class SHRuntimeWarning(RuntimeWarning):
     """A custom runtime warning for sentinelhub-py package"""
 
@@ -55,7 +60,14 @@ class SHRateLimitWarning(SHRuntimeWarning):
     """A custom runtime warning in case user hit the rate limit for downloads"""
 
 
+def show_import_warning(package_name: str) -> None:
+    """A general way of showing import warnings in the package."""
+    message = f"Failed to import {package_name} package. Some sentinelhub-py functionalities might not work correctly!"
+    warnings.warn(message, category=SHImportWarning)
+
+
 warnings.simplefilter("default", SHDeprecationWarning)
 warnings.simplefilter("default", SHUserWarning)
+warnings.simplefilter("always", SHImportWarning)
 warnings.simplefilter("always", SHRuntimeWarning)
 warnings.simplefilter("always", SHRateLimitWarning)

--- a/sentinelhub/io_utils.py
+++ b/sentinelhub/io_utils.py
@@ -11,14 +11,23 @@ from typing import Any, Callable, Dict, Optional
 from xml.etree import ElementTree
 
 import numpy as np
-import tifffile as tiff
-from PIL import Image
 
 from .constants import MimeType
 from .decoding import decode_image_with_pillow, decode_jp2_image, decode_tar, get_data_format
-from .exceptions import SHUserWarning
+from .exceptions import SHUserWarning, show_import_warning
 from .os_utils import create_parent_folder
 from .type_utils import Json
+
+# The following is only for the purpose of using the package within SentinelHub QGIS plugin
+try:
+    import tifffile as tiff
+except ImportError:
+    show_import_warning("tifffile")
+try:
+    from PIL import Image
+except ImportError:
+    show_import_warning("Pillow")
+
 
 LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
A QGIS Python environment doesn't have all dependencies of `sentinelhub-py` and some are too complicated to be shipped with the plugin. Therefore, this solution handles missing dependencies with a warning instead of an error. Therefore the package can work without them.