### PR TITLE
Improve triggers for running CI

### DIFF
--- a/.github/workflows/ci_action.yml
+++ b/.github/workflows/ci_action.yml
@@ -1,13 +1,17 @@
 name: build
 
 on:
+  pull_request:
   push:
+    branches:
+      - 'master'
+      - 'develop'
   schedule:
     - cron: '0 0 * * *'
 
 env:
   # The only way to simulate if-else statement
-  CHECKOUT_BRANCH: ${{ github.event_name == 'push' && github.ref || 'develop' }}
+  CHECKOUT_BRANCH: ${{ github.event_name == 'schedule' && 'develop' || github.ref }}
 
 jobs:
 
@@ -70,9 +74,13 @@ jobs:
       matrix:
         python-version:
           - '3.7'
-          - '3.8'
           - '3.9'
           - '3.10'
+        include: 
+          # A flag marks whether full or partial tests should be run
+          # We don't run integration tests on pull requests from outside repos, because they don't have secrets
+          - python-version: '3.8'
+            full_test_suite: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     steps:
       - name: Checkout branch
         uses: actions/checkout@v2
@@ -92,7 +100,7 @@ jobs:
           pip install -e .[AWS,DEV]
 
       - name: Run full tests and code coverage
-        if: matrix.python-version == '3.8'
+        if: ${{ matrix.full_test_suite }}
         run: |
           sentinelhub.config \
             --sh_client_id "${{ secrets.SH_CLIENT_ID }}" \
@@ -103,12 +111,12 @@ jobs:
           pytest --cov --cov-report=term --cov-report=xml
 
       - name: Run pylint and reduced tests
-        if: matrix.python-version != '3.8'
+        if: ${{ !matrix.full_test_suite }}
         run: |
           pytest -m "not sh_integration and not aws_integration"
 
       - name: Upload code coverage
-        if: matrix.python-version == '3.8'
+        if: ${{ matrix.full_test_suite }}
         uses: codecov/codecov-action@v2
         with:
           files: coverage.xml


### PR DESCRIPTION
CI tests now trigger on pull requests, and push events only trigger them on the master and develop branch. Overall this should decrease the amount of redundant tests, but allow us to test PR branches.

Settings have already been modified in such a way that ALL workflows of outsider collaborators need to be run by a team member.

Tests run for PRs for forks don't include integration tests, so that we have no need for sharing secrets.