### PR TITLE
Added types in tests

### DIFF
--- a/sentinelhub/api/opensearch.py
+++ b/sentinelhub/api/opensearch.py
@@ -92,7 +92,7 @@ def get_area_info(bbox: BBox, date_interval: RawTimeIntervalType, maxcc: Optiona
     return list(result_list)
 
 
-def get_area_dates(bbox: BBox, date_interval: RawTimeIntervalType, maxcc: Optional[int] = None) -> List[dt.date]:
+def get_area_dates(bbox: BBox, date_interval: RawTimeIntervalType, maxcc: Optional[float] = None) -> List[dt.date]:
     """Get list of times of existing images from specified area and time range
 
     :param bbox: bounding box of requested area

--- a/sentinelhub/geopedia/core.py
+++ b/sentinelhub/geopedia/core.py
@@ -339,7 +339,7 @@ class GeopediaFeatureIterator(FeatureIterator[JsonDict]):
 
     def __init__(
         self,
-        layer: str,
+        layer: Union[str, int],
         bbox: Optional[BBox] = None,
         query_filter: Optional[str] = None,
         offset: int = 0,

--- a/sentinelhub/geopedia/request.py
+++ b/sentinelhub/geopedia/request.py
@@ -3,7 +3,7 @@ Data request interface for Geopedia services
 """
 
 from abc import abstractmethod
-from typing import Any, Optional
+from typing import Any, Optional, Union
 
 from ..base import DataRequest
 from ..constants import CRS, MimeType, ServiceType
@@ -17,7 +17,7 @@ class GeopediaRequest(DataRequest):
 
     def __init__(
         self,
-        layer: str,
+        layer: Union[str, int],
         service_type: ServiceType,
         *,
         bbox: BBox,
@@ -63,7 +63,7 @@ class GeopediaWmsRequest(GeopediaRequest):
 
     def __init__(
         self,
-        layer: str,
+        layer: Union[str, int],
         theme: str,
         bbox: BBox,
         *,

--- a/tests/api/batch/test_process.py
+++ b/tests/api/batch/test_process.py
@@ -5,20 +5,30 @@ import datetime as dt
 import itertools as it
 
 import pytest
+from requests_mock import Mocker
 
-from sentinelhub import CRS, BatchRequest, BBox, DataCollection, MimeType, SentinelHubBatch, SentinelHubRequest
+from sentinelhub import (
+    CRS,
+    BatchRequest,
+    BBox,
+    DataCollection,
+    MimeType,
+    SentinelHubBatch,
+    SentinelHubRequest,
+    SHConfig,
+)
 from sentinelhub.constants import ServiceUrl
 
 pytestmark = pytest.mark.sh_integration
 
 
 @pytest.fixture(name="batch_client")
-def batch_client_fixture(config):
+def batch_client_fixture(config: SHConfig) -> SentinelHubBatch:
     return SentinelHubBatch(config=config)
 
 
 @pytest.mark.parametrize("base_url", [ServiceUrl.MAIN, ServiceUrl.USWEST])
-def test_iter_tiling_grids(base_url, config):
+def test_iter_tiling_grids(base_url: str, config: SHConfig) -> None:
     config.sh_base_url = base_url
     batch_client = SentinelHubBatch(config=config)
     tiling_grids = list(batch_client.iter_tiling_grids())
@@ -27,13 +37,13 @@ def test_iter_tiling_grids(base_url, config):
     assert all(isinstance(item, dict) for item in tiling_grids)
 
 
-def test_single_tiling_grid(batch_client):
+def test_single_tiling_grid(batch_client: SentinelHubBatch) -> None:
     tiling_grid = batch_client.get_tiling_grid(0)
 
     assert isinstance(tiling_grid, dict)
 
 
-def test_create_and_run_batch_request(batch_client, requests_mock):
+def test_create_and_run_batch_request(batch_client: SentinelHubBatch, requests_mock: Mocker) -> None:
     """A test that mocks creation and execution of a new batch request"""
     evalscript = "some evalscript"
     time_interval = dt.date(year=2020, month=6, day=1), dt.date(year=2020, month=6, day=10)
@@ -107,7 +117,7 @@ def test_create_and_run_batch_request(batch_client, requests_mock):
         assert requests_mock.request_history[index - len(full_endpoints)].url.endswith(full_endpoint)
 
 
-def test_iter_requests(batch_client):
+def test_iter_requests(batch_client: SentinelHubBatch) -> None:
     batch_requests = list(it.islice(batch_client.iter_requests(), 10))
     assert all(isinstance(request, BatchRequest) for request in batch_requests)
 

--- a/tests/api/batch/test_statistical.py
+++ b/tests/api/batch/test_statistical.py
@@ -2,6 +2,7 @@
 A module that tests an interface for Sentinel Hub Batch processing
 """
 import pytest
+from requests_mock import Mocker
 
 from sentinelhub import (
     CRS,
@@ -10,6 +11,7 @@ from sentinelhub import (
     DataCollection,
     SentinelHubBatchStatistical,
     SentinelHubStatistical,
+    SHConfig,
 )
 from sentinelhub.api.batch.statistical import AccessSpecification
 
@@ -17,11 +19,13 @@ pytestmark = pytest.mark.sh_integration
 
 
 @pytest.fixture(name="statistical_batch_client")
-def statistical_batch_client_fixture(config):
+def statistical_batch_client_fixture(config: SHConfig) -> SentinelHubBatchStatistical:
     return SentinelHubBatchStatistical(config=config)
 
 
-def test_create_and_run_batch_request(statistical_batch_client: SentinelHubBatchStatistical, requests_mock):
+def test_create_and_run_batch_request(
+    statistical_batch_client: SentinelHubBatchStatistical, requests_mock: Mocker
+) -> None:
     """A test that mocks creation and execution of a new batch request"""
     rgb_evalscript = "some evalscript"
 

--- a/tests/api/test_catalog.py
+++ b/tests/api/test_catalog.py
@@ -2,11 +2,12 @@
 Tests for the module with Catalog API interface
 """
 import datetime as dt
+from typing import Union
 
 import dateutil.tz
 import pytest
 
-from sentinelhub import CRS, BBox, DataCollection, Geometry, SentinelHubCatalog
+from sentinelhub import CRS, BBox, DataCollection, Geometry, SentinelHubCatalog, SHConfig
 from sentinelhub.api.catalog import CatalogSearchIterator
 
 TEST_BBOX = BBox([46.16, -16.15, 46.51, -15.58], CRS.WGS84)
@@ -15,14 +16,14 @@ pytestmark = pytest.mark.sh_integration
 
 
 @pytest.fixture(name="catalog")
-def catalog_fixture(config):
+def catalog_fixture(config: SHConfig) -> SentinelHubCatalog:
     return SentinelHubCatalog(config=config)
 
 
 @pytest.mark.parametrize(
     "data_collection", [DataCollection.SENTINEL2_L2A, DataCollection.LANDSAT_TM_L1, DataCollection.SENTINEL3_OLCI]
 )
-def test_info_with_different_deployments(config, data_collection):
+def test_info_with_different_deployments(config: SHConfig, data_collection: DataCollection) -> None:
     """Test if basic interaction works with different data collections on different deployments"""
     config.sh_base_url = data_collection.service_url or config.sh_base_url
     catalog = SentinelHubCatalog(config=config)
@@ -32,13 +33,13 @@ def test_info_with_different_deployments(config, data_collection):
     assert all(link["href"].startswith(config.sh_base_url) for link in info["links"])
 
 
-def test_conformance(catalog):
+def test_conformance(catalog: SentinelHubCatalog) -> None:
     """Test conformance endpoint"""
     conformance = catalog.get_conformance()
     assert isinstance(conformance, dict)
 
 
-def test_get_collections(catalog):
+def test_get_collections(catalog: SentinelHubCatalog) -> None:
     """Tests collections endpoint"""
     collections = catalog.get_collections()
 
@@ -47,13 +48,13 @@ def test_get_collections(catalog):
 
 
 @pytest.mark.parametrize("collection_input", ["sentinel-2-l1c", DataCollection.SENTINEL1_IW])
-def test_get_collection(catalog, collection_input):
+def test_get_collection(catalog: SentinelHubCatalog, collection_input: Union[DataCollection, str]) -> None:
     """Test endpoint for a single collection info"""
     collection_info = catalog.get_collection(collection_input)
     assert isinstance(collection_info, dict)
 
 
-def test_get_feature(catalog):
+def test_get_feature(catalog: SentinelHubCatalog) -> None:
     """Test endpoint for a single feature info"""
     feature_id = "S2B_MSIL2A_20200318T120639_N0214_R080_T24FWD_20200318T135608"
     feature_info = catalog.get_feature(DataCollection.SENTINEL2_L2A, feature_id)
@@ -62,7 +63,7 @@ def test_get_feature(catalog):
     assert feature_info["id"] == feature_id
 
 
-def test_search_bbox(catalog):
+def test_search_bbox(catalog: SentinelHubCatalog) -> None:
     """Tests search with bounding box"""
     time_interval = "2021-01-01T00:00:00", "2021-01-15T00:00:10"
     cloud_cover_interval = 10, 50
@@ -84,7 +85,7 @@ def test_search_bbox(catalog):
         assert cloud_cover_interval[0] <= result["properties"]["eo:cloud_cover"] <= cloud_cover_interval[1]
 
 
-def test_search_geometry_and_iterator_methods(catalog):
+def test_search_geometry_and_iterator_methods(catalog: SentinelHubCatalog) -> None:
     """Tests search with a geometry and test methods of CatalogSearchIterator"""
     search_geometry = Geometry(TEST_BBOX.geometry, crs=TEST_BBOX.crs)
 
@@ -130,7 +131,9 @@ def test_search_geometry_and_iterator_methods(catalog):
         ),
     ],
 )
-def test_search_for_data_collection(config, data_collection, feature_id):
+def test_search_for_data_collection(
+    config: SHConfig, data_collection: Union[DataCollection, str], feature_id: str
+) -> None:
     """Tests search functionality for each data collection to confirm compatibility between DataCollection parameters
     and Catalog API
     """
@@ -149,7 +152,7 @@ def test_search_for_data_collection(config, data_collection, feature_id):
     assert result["id"] == feature_id
 
 
-def test_search_with_ids(config):
+def test_search_with_ids(config: SHConfig) -> None:
     """Tests a search without time and bbox parameters"""
     tile_id = "LE07_L1TP_160071_20170110_20201008_02_T1"
     config.sh_base_url = DataCollection.LANDSAT_ETM_L1.service_url

--- a/tests/api/test_fis.py
+++ b/tests/api/test_fis.py
@@ -37,7 +37,7 @@ class FisTestCase:
     result_length: int
     save_data: bool = False
 
-    def collect_data(self, output_folder):
+    def collect_data(self, output_folder: str) -> list:
         request = FisRequest(**self.kwargs, data_folder=output_folder)
         if self.save_data:
             request.save_data(redownload=True)
@@ -110,7 +110,7 @@ TEST_CASES = [
 
 @pytest.mark.sh_integration
 @pytest.mark.parametrize("test_case", TEST_CASES)
-def test_fis(output_folder, test_case):
+def test_fis(output_folder: str, test_case: FisTestCase) -> None:
     with pytest.warns(SHDeprecationWarning):
         data = test_case.collect_data(output_folder)
     assert len(data) == test_case.result_length

--- a/tests/api/test_ogc.py
+++ b/tests/api/test_ogc.py
@@ -40,10 +40,10 @@ class OgcTestCase:
     date_check: Optional[datetime.datetime] = None
     save_data: bool = False
 
-    def initialize_request(self, output_folder):
+    def initialize_request(self, output_folder: str) -> OgcRequest:
         return self.constructor(**self.kwargs, data_folder=output_folder)
 
-    def collect_data(self, request):
+    def collect_data(self, request: OgcRequest) -> list:
         if self.save_data:
             request.save_data(redownload=True, data_filter=self.data_filter)
             return request.get_data(save_data=True, data_filter=self.data_filter)
@@ -468,7 +468,7 @@ TEST_CASES = [
 
 
 @pytest.mark.parametrize("test_case", TEST_CASES)
-def test_ogc(test_case, output_folder):
+def test_ogc(test_case: OgcTestCase, output_folder: str) -> None:
     # Run data collection
     request = test_case.initialize_request(output_folder)
     data = test_case.collect_data(request)
@@ -502,7 +502,7 @@ def test_ogc(test_case, output_folder):
     )
 
 
-def test_too_large_request():
+def test_too_large_request() -> None:
     bbox = BBox((-5.23, 48.0, -5.03, 48.17), CRS.WGS84)
     request = WmsRequest(
         data_collection=DataCollection.SENTINEL2_L1C,

--- a/tests/api/test_ogc_base.py
+++ b/tests/api/test_ogc_base.py
@@ -5,7 +5,7 @@ from sentinelhub.download.models import DownloadResponse
 
 
 @pytest.fixture(name="wcs_request")
-def wcs_request_fixture(output_folder):
+def wcs_request_fixture(output_folder: str) -> WcsRequest:
     bbox = BBox((111.7, 8.655, 111.6, 8.688), crs=CRS.WGS84)
     return WcsRequest(
         data_folder=output_folder, bbox=bbox, data_collection=DataCollection.SENTINEL2_L1C, layer="TRUE-COLOR-S2-L1C"
@@ -13,7 +13,7 @@ def wcs_request_fixture(output_folder):
 
 
 @pytest.mark.sh_integration
-def test_init(output_folder, wcs_request):
+def test_init(output_folder: str, wcs_request: WcsRequest) -> None:
     wcs_request.create_request(reset_wfs_iterator=True)  # This method is used by s2cloudless, don't rename it
 
     assert wcs_request.data_folder == output_folder
@@ -30,7 +30,7 @@ def test_init(output_folder, wcs_request):
 
 
 @pytest.mark.sh_integration
-def test_encoded_latest_result(wcs_request):
+def test_encoded_latest_result(wcs_request: WcsRequest) -> None:
     result_list = wcs_request.get_data(decode_data=False, save_data=True)
 
     assert isinstance(result_list, list)

--- a/tests/api/test_opensearch.py
+++ b/tests/api/test_opensearch.py
@@ -4,12 +4,12 @@ Tests for Sentinel Hub Opensearch service interface
 from sentinelhub import CRS, BBox, get_area_dates, get_tile_info
 
 
-def test_get_tile_info():
+def test_get_tile_info() -> None:
     tile_info = get_tile_info("T17SNV", "2015-11-29", aws_index=1)
     assert isinstance(tile_info, dict)
 
 
-def test_get_area_dates():
+def test_get_area_dates() -> None:
     bbox = BBox([1059111.463919402, 4732980.791418114, 1061557.4488245277, 4735426.776323237], crs=CRS.POP_WEB)
     dates = get_area_dates(bbox, ("2016-01-23", "2016-11-24"), maxcc=0.7)
     assert isinstance(dates, list)

--- a/tests/api/test_process.py
+++ b/tests/api/test_process.py
@@ -1,6 +1,7 @@
 """ Tests for the Process API requests
 """
 import json
+from typing import Any, Dict
 
 import pytest
 from oauthlib.oauth2.rfc6749.errors import CustomOAuth2Error
@@ -26,7 +27,7 @@ from sentinelhub.testing_utils import test_numpy_data
 pytestmark = pytest.mark.sh_integration
 
 
-def test_single_jpg():
+def test_single_jpg() -> None:
     """Test downloading three bands of L1C"""
     evalscript = """
         //VERSION=3
@@ -69,7 +70,7 @@ def test_single_jpg():
     )
 
 
-def test_other_args(config, output_folder):
+def test_other_args(config: SHConfig, output_folder: str) -> None:
     """Test downloading three bands of L1C"""
     evalscript = """
         //VERSION=3
@@ -113,7 +114,7 @@ def test_other_args(config, output_folder):
     )
 
 
-def test_preview_mode():
+def test_preview_mode() -> None:
     """Test downloading three bands of L1C"""
     evalscript = """
         //VERSION=3
@@ -158,7 +159,7 @@ def test_preview_mode():
     )
 
 
-def test_resolution_parameter():
+def test_resolution_parameter() -> None:
     """Test downloading three bands of L1C"""
     evalscript = """
         //VERSION=3
@@ -202,7 +203,7 @@ def test_resolution_parameter():
     )
 
 
-def test_multipart_tar():
+def test_multipart_tar() -> None:
     """Test downloading multiple outputs, packed into a TAR file"""
     evalscript = """
         //VERSION=3
@@ -263,7 +264,7 @@ def test_multipart_tar():
     assert json_data["norm_factor"] == 0.0001
 
 
-def test_multipart_geometry():
+def test_multipart_geometry() -> None:
     evalscript = """
         //VERSION=3
 
@@ -405,7 +406,7 @@ def test_multipart_geometry():
     assert json_data["rgb_ratios"] == approx(expected_ratios)
 
 
-def test_bad_credentials():
+def test_bad_credentials() -> None:
     evalscript = """
                 //VERSION=3
 
@@ -421,7 +422,7 @@ def test_bad_credentials():
                     return [2.5 * sample.B04, 2.5 * sample.B03, 2.5 * sample.B02];
                 }
             """
-    request_params = dict(
+    request_params: Dict[str, Any] = dict(
         evalscript=evalscript,
         input_data=[
             SentinelHubRequest.input_data(
@@ -449,7 +450,7 @@ def test_bad_credentials():
         request.get_data()
 
 
-def test_data_fusion(config):
+def test_data_fusion(config: SHConfig) -> None:
     evalscript = """
     //VERSION=3
     function setup() {
@@ -512,12 +513,12 @@ def test_data_fusion(config):
     assert request.download_list[0].url == f"{ServiceUrl.MAIN}/api/v1/process"
 
 
-def test_conflicting_service_url_restrictions(config):
+def test_conflicting_service_url_restrictions(config: SHConfig) -> None:
     """This data fusion attempt is expected to raise an error because config URL is not one of the URLs of data
     collections.
     """
     config.sh_base_url = ServiceUrl.MAIN
-    request_params = dict(
+    request_params: Dict[str, Any] = dict(
         evalscript="",
         input_data=[
             SentinelHubRequest.input_data(data_collection=DataCollection.LANDSAT_OT_L2),
@@ -533,7 +534,7 @@ def test_conflicting_service_url_restrictions(config):
         SentinelHubRequest(**request_params)
 
 
-def test_bbox_geometry():
+def test_bbox_geometry() -> None:
     """Test intersection between bbox and geometry"""
     evalscript = """
         //VERSION=3
@@ -582,7 +583,7 @@ def test_bbox_geometry():
     )
 
 
-def test_basic_functionalities():
+def test_basic_functionalities() -> None:
     normal_dict = {"a": 10, "b": {"c": 20, 30: "d"}}
     service_url = "xyz"
     input_data_dict = InputDataDict(normal_dict, service_url=service_url)

--- a/tests/api/test_statistical.py
+++ b/tests/api/test_statistical.py
@@ -1,9 +1,12 @@
 """
 Tests for the module with Statistical API
 """
+from typing import Any, Dict, Optional, Tuple
+
 import pytest
 
 from sentinelhub import CRS, BBox, DataCollection, Geometry, SentinelHubStatistical
+from sentinelhub.type_utils import JsonDict
 
 EVALSCRIPT = """
 //VERSION=3
@@ -82,17 +85,17 @@ GEOMETRY = Geometry(BBOX.geometry, crs=BBOX.crs)
     ],
 )
 def test_statistical_api(
-    evalscript,
-    bbox,
-    geometry,
-    time_interval,
-    resolution,
-    aggregation_interval,
-    data_collection,
-    data_filters,
-    calculations,
-    results,
-):
+    evalscript: str,
+    bbox: Optional[BBox],
+    geometry: Optional[Geometry],
+    time_interval: Tuple[str, str],
+    resolution: Tuple[float, float],
+    aggregation_interval: str,
+    data_collection: DataCollection,
+    data_filters: Dict[str, Any],
+    calculations: Optional[JsonDict],
+    results: JsonDict,
+) -> None:
     aggregation = SentinelHubStatistical.aggregation(
         evalscript=evalscript,
         time_interval=time_interval,

--- a/tests/api/test_wfs.py
+++ b/tests/api/test_wfs.py
@@ -2,6 +2,7 @@
 Test for Sentinel Hub WFS
 """
 import datetime
+from typing import Any, Dict
 
 import pytest
 from shapely.geometry import MultiPolygon
@@ -29,7 +30,7 @@ pytestmark = pytest.mark.sh_integration
         ),
     ],
 )
-def test_wfs(args, kwargs, expected_len):
+def test_wfs(args: list, kwargs: Dict[str, Any], expected_len: int) -> None:
     iterator = WebFeatureService(*args, **kwargs)
     features = list(iterator)
     dates = iterator.get_dates()

--- a/tests/aws/test_data.py
+++ b/tests/aws/test_data.py
@@ -8,7 +8,7 @@ from sentinelhub.aws import AwsProductRequest, AwsTileRequest
 pytestmark = pytest.mark.aws_integration
 
 
-def test_aws_tile(output_folder):
+def test_aws_tile(output_folder: str) -> None:
     request = AwsTileRequest(
         data_folder=output_folder,
         bands="B01, B05",
@@ -24,7 +24,7 @@ def test_aws_tile(output_folder):
     assert np.mean(data[0]) == approx(1357.99, abs=1e-1)
 
 
-def test_aws_product(output_folder):
+def test_aws_product(output_folder: str) -> None:
     request = AwsProductRequest(
         data_folder=output_folder,
         bands="B10",
@@ -37,7 +37,7 @@ def test_aws_product(output_folder):
     assert len(data) == 51
 
 
-def test_partial_aws_product(output_folder):
+def test_partial_aws_product(output_folder: str) -> None:
     request = AwsProductRequest(
         data_folder=output_folder,
         bands="B12",
@@ -55,7 +55,7 @@ def test_partial_aws_product(output_folder):
     assert len(data) == 1
 
 
-def test_l2a_product(output_folder):
+def test_l2a_product(output_folder: str) -> None:
     request = AwsProductRequest(
         data_folder=output_folder,
         metafiles="metadata,tileInfo,productInfo, datastrip/*/metadata",

--- a/tests/aws/test_data_safe.py
+++ b/tests/aws/test_data_safe.py
@@ -1,4 +1,5 @@
 import os
+from typing import Any, Dict
 
 import pytest
 
@@ -7,7 +8,7 @@ from sentinelhub.aws import AwsConstants, AwsProductRequest, AwsTileRequest
 
 
 @pytest.fixture(name="safe_folder", scope="session")
-def safe_folder_fixture(input_folder):
+def safe_folder_fixture(input_folder: str) -> str:
     """Provides a folder each file contains a definition of a .SAFE structure on how it will be reconstructed from
     files from AWS S3 buckets."""
     return os.path.join(input_folder, "aws_safe")
@@ -70,7 +71,7 @@ TEST_CASES = [
 
 @pytest.mark.aws_integration
 @pytest.mark.parametrize("test_name, product_id, params", TEST_CASES)
-def test_safe_struct(test_name, product_id, params, safe_folder):
+def test_safe_struct(test_name: str, product_id: str, params: Dict[str, Any], safe_folder: str) -> None:
     params = dict(
         safe_format=True,
         **params,

--- a/tests/aws/test_request.py
+++ b/tests/aws/test_request.py
@@ -7,7 +7,7 @@ from sentinelhub.aws import AwsProductRequest
 
 
 @pytest.mark.aws_integration
-def test_saving_responses(output_folder):
+def test_saving_responses(output_folder: str) -> None:
     product_id = "S2A_MSIL1C_20180113T001101_N0206_R073_T55KGP_20180113T013328.SAFE"
     metafiles = "inspire "
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,12 +26,12 @@ def pytest_configure(config):
 
 
 @pytest.fixture(name="config")
-def config_fixture():
+def config_fixture() -> SHConfig:
     return SHConfig()
 
 
 @pytest.fixture(name="input_folder", scope="session")
-def input_folder_fixture():
+def input_folder_fixture() -> str:
     return INPUT_FOLDER
 
 
@@ -45,7 +45,7 @@ def output_folder_fixture():
 
 
 @pytest.fixture(name="logger")
-def logger_fixture():
+def logger_fixture() -> logging.Logger:
     logging.basicConfig(
         level=logging.INFO, format="%(asctime)-15s %(module)s:%(lineno)d [%(levelname)s] %(funcName)s  %(message)s"
     )
@@ -53,7 +53,7 @@ def logger_fixture():
 
 
 @pytest.fixture(name="session", scope="session")
-def session_fixture():
+def session_fixture() -> SentinelHubSession:
     return SentinelHubSession()
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,8 +4,10 @@ Module with global fixtures
 import logging
 import os
 import shutil
+from typing import Any, Generator
 
 import pytest
+from pytest import Config
 
 from sentinelhub import SentinelHubSession, SHConfig
 
@@ -16,7 +18,7 @@ INPUT_FOLDER = get_input_folder(__file__)
 OUTPUT_FOLDER = get_output_folder(__file__)
 
 
-def pytest_configure(config):
+def pytest_configure(config: Config) -> None:
     shconfig = SHConfig()
     for param in shconfig.get_params():
         env_variable = param.upper()
@@ -36,7 +38,7 @@ def input_folder_fixture() -> str:
 
 
 @pytest.fixture(name="output_folder")
-def output_folder_fixture():
+def output_folder_fixture() -> Generator[str, None, None]:
     """Creates the necessary folder and cleans up after test is done."""
     if not os.path.exists(OUTPUT_FOLDER):
         os.mkdir(OUTPUT_FOLDER)
@@ -58,7 +60,7 @@ def session_fixture() -> SentinelHubSession:
 
 
 @pytest.fixture(name="ray")
-def ray_fixture():
+def ray_fixture() -> Generator[Any, None, None]:
     """Ensures that the ray server will stop even if test fails"""
     ray = pytest.importorskip("ray")
     ray.init(log_to_driver=False)

--- a/tests/download/test_sentinelhub_client.py
+++ b/tests/download/test_sentinelhub_client.py
@@ -1,3 +1,5 @@
+from typing import Type, Union
+
 import pytest
 from requests_mock import Mocker
 
@@ -14,7 +16,7 @@ FAST_SH_ENDPOINT = "https://services.sentinel-hub.com/api/v1/catalog/collections
 
 
 @pytest.mark.sh_integration
-def test_client_with_fixed_session(session):
+def test_client_with_fixed_session(session: SentinelHubSession) -> None:
     blank_config = SHConfig(use_defaults=True)
     client = SentinelHubDownloadClient(session=session, config=blank_config)
 
@@ -25,7 +27,7 @@ def test_client_with_fixed_session(session):
     assert info
 
     with pytest.raises(ValueError):
-        SentinelHubDownloadClient(session=blank_config, config=blank_config)
+        SentinelHubDownloadClient(session=blank_config, config=blank_config)  # type: ignore[arg-type]
 
 
 @pytest.mark.sh_integration
@@ -51,7 +53,9 @@ def test_client_headers(request_type: RequestType, session: SentinelHubSession, 
 
 @pytest.mark.sh_integration
 @pytest.mark.parametrize("client_object", [SentinelHubDownloadClient, SentinelHubDownloadClient()])
-def test_session_caching_and_clearing(client_object, session):
+def test_session_caching_and_clearing(
+    client_object: Union[SentinelHubDownloadClient, Type[SentinelHubDownloadClient]], session: SentinelHubSession
+) -> None:
     client_object.clear_cache()
     assert SentinelHubDownloadClient._CACHED_SESSIONS == {}
 
@@ -64,7 +68,7 @@ def test_session_caching_and_clearing(client_object, session):
 
 
 @pytest.mark.sh_integration
-def test_double_session_caching(session):
+def test_double_session_caching(session: SentinelHubSession) -> None:
     another_session = SentinelHubSession()
 
     client = SentinelHubDownloadClient()
@@ -82,7 +86,7 @@ def test_double_session_caching(session):
 
 
 @pytest.mark.sh_integration
-def test_session_caching_on_subclass(session):
+def test_session_caching_on_subclass(session: SentinelHubSession) -> None:
     statistical_client = SentinelHubStatisticalDownloadClient()
     statistical_client.cache_session(session)
 
@@ -95,7 +99,7 @@ def test_session_caching_on_subclass(session):
 
 
 @pytest.mark.sh_integration
-def test_universal_session_caching(session):
+def test_universal_session_caching(session: SentinelHubSession) -> None:
     SentinelHubDownloadClient.clear_cache()
 
     config_without_credentials = SHConfig(use_defaults=True)

--- a/tests/test_areas.py
+++ b/tests/test_areas.py
@@ -1,5 +1,6 @@
 import itertools
 import os
+from typing import Any, Dict, List, Tuple, Type, Union
 
 import pytest
 import shapely.geometry
@@ -16,6 +17,7 @@ from sentinelhub import (
     UtmZoneSplitter,
     read_data,
 )
+from sentinelhub.areas import AreaSplitter
 from sentinelhub.testing_utils import get_input_folder
 
 geojson = read_data(os.path.join(get_input_folder(__file__), "cies_islands.json"))
@@ -56,14 +58,14 @@ BBOX_GRID = [
         ),
     ],
 )
-def test_return_type(constructor, args, kwargs, bbox_len):
+def test_return_type(constructor: Type[AreaSplitter], args: list, kwargs: Dict[str, Any], bbox_len: int) -> None:
     splitter = constructor(*args, **kwargs)
-    return_lists = [
+
+    return_lists: List[Tuple[list, Union[Type, Tuple[Type, ...]]]] = [
         (splitter.get_bbox_list(buffer=0.2), BBox),
         (splitter.get_info_list(), dict),
         (splitter.get_geometry_list(), (shapely.geometry.Polygon, shapely.geometry.MultiPolygon)),
     ]
-
     for return_list, item_type in return_lists:
         assert isinstance(return_list, list)
         assert len(return_list) == bbox_len

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -2,6 +2,7 @@
 Tests for sh_utils.py module
 """
 import math
+from typing import List
 
 import pytest
 
@@ -12,7 +13,7 @@ from sentinelhub.base import FeatureIterator
 class DummyIterator(FeatureIterator):
     """As features it generates integer values"""
 
-    def __init__(self, total, limit):
+    def __init__(self, total: int, limit: int):
         """
         :param total: Number of features in total
         :param limit: Max number of features provided by each fetch
@@ -23,7 +24,7 @@ class DummyIterator(FeatureIterator):
         self.feature_fetch_count = 0
         super().__init__(client=DownloadClient(), url="")
 
-    def _fetch_features(self):
+    def _fetch_features(self) -> List[int]:
         start_interval = len(self.features)
         end_interval = min(start_interval + self.limit, self.total)
 
@@ -38,7 +39,7 @@ class DummyIterator(FeatureIterator):
 
 
 @pytest.mark.parametrize("total,limit", [(100, 1000), (100, 10), (100, 7), (100, 1)])
-def test_feature_iterator(total, limit):
+def test_feature_iterator(total: int, limit: int) -> None:
     iterator = DummyIterator(total, limit)
 
     for _ in range(2):

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -33,5 +33,5 @@ URL = "https://roda.sentinel-hub.com/sentinel-s2-l1c/tiles/54/H/VH/2017/4/14/0/m
         "sentinelhub.download --help",
     ],
 )
-def test_return_type(output_folder, command):
+def test_return_type(output_folder: str, command: str) -> None:
     assert subprocess.call(command, shell=True) == 0

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,6 +3,7 @@ Unit tests for config.py module
 """
 import json
 import os
+from typing import Any, Generator
 
 import pytest
 
@@ -10,7 +11,7 @@ from sentinelhub import SHConfig
 
 
 @pytest.fixture(name="restore_config")
-def restore_config_fixture():
+def restore_config_fixture() -> Generator[None, None, None]:
     """A fixture that makes sure original config is restored after a test is executed. It restores the config even if
     a test has failed.
     """
@@ -19,7 +20,7 @@ def restore_config_fixture():
     original_config.save()
 
 
-def test_config_file():
+def test_config_file() -> None:
     config = SHConfig()
 
     config_file = config.get_config_location()
@@ -38,7 +39,7 @@ def test_config_file():
         assert config[param] == value
 
 
-def test_reset():
+def test_reset() -> None:
     config = SHConfig()
     default_config = SHConfig(use_defaults=True)
 
@@ -57,11 +58,11 @@ def test_reset():
     assert config.instance_id == default_config.instance_id, "Instance ID should reset"
 
 
-def test_save(restore_config):
+def test_save(restore_config: None) -> None:
     config = SHConfig()
     old_value = config.download_timeout_seconds
 
-    config.download_timeout_seconds = "abcd"
+    config.download_timeout_seconds = "abcd"  # type: ignore[assignment]
     with pytest.raises(ValueError):
         config.save()
 
@@ -76,7 +77,7 @@ def test_save(restore_config):
     assert config.download_timeout_seconds == new_value, "Saved value should have changed"
 
 
-def test_copy():
+def test_copy() -> None:
     config = SHConfig(hide_credentials=True)
     config.instance_id = "a"
 
@@ -89,7 +90,7 @@ def test_copy():
     assert config.instance_id == "a"
 
 
-def test_config_equality():
+def test_config_equality() -> None:
     assert SHConfig() != 42
 
     config1 = SHConfig(hide_credentials=False, use_defaults=True)
@@ -102,7 +103,7 @@ def test_config_equality():
     assert config1 != config2
 
 
-def test_raise_for_missing_instance_id():
+def test_raise_for_missing_instance_id() -> None:
     config = SHConfig()
 
     config.instance_id = "xxx"
@@ -114,7 +115,7 @@ def test_raise_for_missing_instance_id():
 
 
 @pytest.mark.parametrize("hide_credentials", [False, True])
-def test_config_repr(hide_credentials):
+def test_config_repr(hide_credentials: bool) -> None:
     config = SHConfig(hide_credentials=hide_credentials)
     config.instance_id = "a" * 20
     config_repr = repr(config)
@@ -130,7 +131,7 @@ def test_config_repr(hide_credentials):
 
 
 @pytest.mark.parametrize("hide_credentials", [False, True])
-def test_get_config_dict(hide_credentials):
+def test_get_config_dict(hide_credentials: bool) -> None:
     config = SHConfig(hide_credentials=hide_credentials)
     config.sh_client_secret = "x" * 15
     config.aws_secret_access_key = "y" * 10
@@ -147,14 +148,14 @@ def test_get_config_dict(hide_credentials):
         assert config_dict["aws_secret_access_key"] == config.aws_secret_access_key
 
 
-def test_transfer_with_ray(ray):
+def test_transfer_with_ray(ray: Any) -> None:
     """This test makes sure that the process of transferring SHConfig object to a Ray worker, working with it, and
     sending it back works correctly.
     """
     config = SHConfig()
     config.instance_id = "x"
 
-    def _remote_ray_testing(remote_config):
+    def _remote_ray_testing(remote_config: SHConfig) -> SHConfig:
         """Makes a few checks and modifications to the config object"""
         assert repr(remote_config).startswith("SHConfig")
         assert isinstance(remote_config.get_config_dict(), dict)

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -1,6 +1,7 @@
 """
 Tests for constants.py module
 """
+from typing import Any, Type
 
 import numpy as np
 import pyproj
@@ -22,7 +23,7 @@ from sentinelhub.exceptions import SHUserWarning
         (13, -46, "32733"),
     ],
 )
-def test_utm(lng, lat, epsg):
+def test_utm(lng: float, lat: float, epsg: str) -> None:
     crs = CRS.get_utm_from_wgs84(lng, lat)
     assert epsg == crs.value
 
@@ -43,13 +44,13 @@ def test_utm(lng, lat, epsg):
         (pyproj.CRS(3857), CRS.POP_WEB),
     ],
 )
-def test_crs_parsing(parse_value, expected):
+def test_crs_parsing(parse_value: Any, expected: CRS) -> None:
     parsed_result = CRS(parse_value)
     assert parsed_result == expected
 
 
 @pytest.mark.parametrize("parse_value, expected, warning", [(pyproj.CRS(4326), CRS.WGS84, SHUserWarning)])
-def test_crs_parsing_warn(parse_value, expected, warning):
+def test_crs_parsing_warn(parse_value: Any, expected: CRS, warning: Type[Warning]) -> None:
     with pytest.warns(warning):
         parsed_result = CRS(parse_value)
         assert parsed_result == expected
@@ -64,7 +65,7 @@ def test_crs_parsing_warn(parse_value, expected, warning):
         (CRS.UTM_33S, "EPSG:32733"),
     ],
 )
-def test_ogc_string(crs, epsg):
+def test_ogc_string(crs: CRS, epsg: str) -> None:
     ogc_str = CRS.ogc_string(crs)
     assert epsg == ogc_str
 
@@ -82,12 +83,12 @@ def test_ogc_string(crs, epsg):
         (CRS("32733"), "CRS('32733')"),
     ],
 )
-def test_crs_repr(crs, crs_repr):
+def test_crs_repr(crs: CRS, crs_repr: str) -> None:
     assert crs_repr == repr(crs)
 
 
 @pytest.mark.parametrize("crs", CRS)
-def test_crs_has_value(crs):
+def test_crs_has_value(crs: CRS) -> None:
     assert CRS.has_value(crs.value), f"Expected support for CRS {crs.value}"
 
 
@@ -95,7 +96,7 @@ def test_crs_has_value(crs):
     "value, fails",
     [("string", True), (-1, True), (999, True), (None, True), (3035, False), ("EPSG:3035", False), (10000, False)],
 )
-def test_custom_crs(value, fails):
+def test_custom_crs(value: Any, fails: bool) -> None:
     if fails:
         with pytest.raises(ValueError):
             CRS(value)
@@ -107,7 +108,7 @@ def test_custom_crs(value, fails):
 
 
 @pytest.mark.parametrize("crs", [CRS.WGS84, CRS.POP_WEB, CRS.UTM_38N])
-def test_pyproj_methods(crs):
+def test_pyproj_methods(crs: CRS) -> None:
     assert isinstance(crs.projection(), pyproj.Proj)
     assert isinstance(crs.pyproj_crs(), pyproj.CRS)
 
@@ -123,19 +124,19 @@ def test_pyproj_methods(crs):
         *[(mime_type.extension, mime_type) for mime_type in MimeType],
     ],
 )
-def test_mime_type_from_string(ext, mime_type):
+def test_mime_type_from_string(ext: str, mime_type: MimeType) -> None:
     assert MimeType.from_string(ext) == mime_type
 
 
 @pytest.mark.parametrize("faulty_arg", ["unknown ext", "tiff;depth=32f"])
-def test_mimetype_no_value_fail(faulty_arg):
+def test_mimetype_no_value_fail(faulty_arg: str) -> None:
     assert not MimeType.has_value(faulty_arg), "This value is not supposed to be type of the Enum"
     with pytest.raises(ValueError):
         MimeType.from_string(faulty_arg)
 
 
 @pytest.mark.parametrize("ext", ["tif", "tiff", "jpg", "jpeg", "png", "jp2"])
-def test_is_image_format(ext):
+def test_is_image_format(ext: str) -> None:
     mime_type = MimeType.from_string(ext)
     assert MimeType.is_image_format(mime_type)
 
@@ -155,7 +156,7 @@ def test_is_image_format(ext):
         (MimeType.TAR, "application/x-tar"),
     ],
 )
-def test_get_string(mime_type, expected_string):
+def test_get_string(mime_type: MimeType, expected_string: str) -> None:
     assert MimeType.get_string(mime_type) == expected_string
     assert MimeType.from_string(expected_string) == mime_type, "Result of `get_string` not accepted by `from_string`"
 
@@ -164,11 +165,11 @@ def test_get_string(mime_type, expected_string):
     "mime_type, path, expected_answer",
     [(MimeType.NPY, "some/path/file.npy", True), (MimeType.GPKG, "file.gpkg.gz", False)],
 )
-def test_matches_extension(mime_type, path, expected_answer):
+def test_matches_extension(mime_type: MimeType, path: str, expected_answer: bool) -> None:
     assert mime_type.matches_extension(path) == expected_answer
 
 
-def test_get_expected_max_value():
+def test_get_expected_max_value() -> None:
     assert MimeType.TIFF.get_expected_max_value() == 65535
     assert MimeType.PNG.get_expected_max_value() == 255
 
@@ -176,7 +177,7 @@ def test_get_expected_max_value():
         MimeType.TAR.get_expected_max_value()
 
 
-def test_request_type():
+def test_request_type() -> None:
     with pytest.raises(ValueError):
         RequestType("post")
 

--- a/tests/test_data_collections.py
+++ b/tests/test_data_collections.py
@@ -1,13 +1,15 @@
 """
 Unit tests for data_collections module
 """
+from typing import Any
+
 import pytest
 
 from sentinelhub import DataCollection
 from sentinelhub.data_collections import DataCollectionDefinition
 
 
-def test_repr():
+def test_repr() -> None:
     definition = DataCollection.SENTINEL1_IW.value
     representation = repr(definition)
 
@@ -15,7 +17,7 @@ def test_repr():
     assert representation.count("\n") >= 5
 
 
-def test_derive():
+def test_derive() -> None:
     definition = DataCollectionDefinition(api_id="X", wfs_id="Y")
     derived_definition = definition.derive(wfs_id="Z")
 
@@ -24,14 +26,14 @@ def test_derive():
     assert derived_definition.collection_type is None
 
 
-def test_compare():
+def test_compare() -> None:
     def1 = DataCollectionDefinition(api_id="X", _name="A")
     def2 = DataCollectionDefinition(api_id="X", _name="B")
 
     assert def1 == def2
 
 
-def test_define():
+def test_define() -> None:
     for _ in range(3):
         data_collection = DataCollection.define(
             "NEW", api_id="X", sensor_type="Sensor", bands=("B01",), is_timeless=True
@@ -46,7 +48,7 @@ def test_define():
         DataCollection.define("NEW", api_id="Y")
 
 
-def test_define_from():
+def test_define_from() -> None:
     bands = ["B01", "XYZ"]
     for _ in range(3):
         data_collection = DataCollection.define_from(DataCollection.SENTINEL5P, "NEW_5P", api_id="X", bands=bands)
@@ -57,7 +59,7 @@ def test_define_from():
     assert data_collection.bands == tuple(bands)
 
 
-def test_define_byoc_and_batch():
+def test_define_byoc_and_batch() -> None:
     byoc_id = "0000d273-7e89-4f00-971e-9024f89a0000"
     byoc = DataCollection.define_byoc(byoc_id, name="MY_BYOC")
     batch = DataCollection.define_batch(byoc_id, name="MY_BATCH")
@@ -70,7 +72,7 @@ def test_define_byoc_and_batch():
         assert data_collection.collection_id == byoc_id
 
 
-def test_attributes():
+def test_attributes() -> None:
     data_collection = DataCollection.SENTINEL3_OLCI
 
     for attr_name in ["api_id", "catalog_id", "wfs_id", "service_url", "bands", "sensor_type"]:
@@ -87,7 +89,7 @@ def test_attributes():
     assert data_collection.service_url is None
 
 
-def test_sentinel1_checks():
+def test_sentinel1_checks() -> None:
     assert DataCollection.SENTINEL1_IW.is_sentinel1
     assert not DataCollection.SENTINEL2_L1C.is_sentinel1
 
@@ -97,18 +99,18 @@ def test_sentinel1_checks():
     assert DataCollection.SENTINEL2_L2A.contains_orbit_direction("descending")
 
 
-def test_get_available_collections():
+def test_get_available_collections() -> None:
     collections = DataCollection.get_available_collections()
     assert helper_check_collection_list(collections)
 
 
-def helper_check_collection_list(collection_list):
+def helper_check_collection_list(collection_list: Any) -> bool:
     is_list = isinstance(collection_list, list)
     contains_collections = all(isinstance(data_collection, DataCollection) for data_collection in collection_list)
     return is_list and contains_collections
 
 
-def test_transfer_with_ray(ray):
+def test_transfer_with_ray(ray: Any) -> None:
     """This test makes sure that the process of transferring a custom DataCollection object to a Ray worker and back
     works correctly.
     """

--- a/tests/test_geo_utils.py
+++ b/tests/test_geo_utils.py
@@ -1,28 +1,30 @@
 """
 Test for geo_utils module and correctness of geographical transformations
 """
+from typing import Tuple, Union
+
 import pytest
 
 from sentinelhub import CRS, BBox, geo_utils
 
 
-def test_wgs84_to_utm():
+def test_wgs84_to_utm() -> None:
     x, y = geo_utils.wgs84_to_utm(15.525078, 44.1440478, CRS.UTM_33N)
     assert (x, y) == pytest.approx((541995.694062, 4888006.132887), rel=1e-8)
 
 
-def test_to_wgs84():
+def test_to_wgs84() -> None:
     lng, lat = geo_utils.to_wgs84(541995.694062, 4888006.132887, CRS.UTM_33N)
     assert (lng, lat) == pytest.approx((15.525078, 44.1440478), rel=1e-8)
 
 
-def test_get_utm_crs():
+def test_get_utm_crs() -> None:
     lng, lat = 15.52, 44.14
     crs = geo_utils.get_utm_crs(lng, lat)
     assert crs is CRS.UTM_33N
 
 
-def test_bbox_to_resolution():
+def test_bbox_to_resolution() -> None:
     bbox = BBox(((111.644, 8.655), (111.7, 8.688)), CRS.WGS84)
     resx, resy = geo_utils.bbox_to_resolution(bbox, 512, 512)
 
@@ -30,14 +32,16 @@ def test_bbox_to_resolution():
 
 
 @pytest.mark.parametrize("resolution, expected_dimensions", [(10, (615, 366)), ((20, 50), (308, 73))])
-def test_bbox_to_dimensions(resolution, expected_dimensions):
+def test_bbox_to_dimensions(
+    resolution: Union[float, Tuple[float, float]], expected_dimensions: Tuple[int, int]
+) -> None:
     bbox = BBox(((111.644, 8.655), (111.7, 8.688)), CRS.WGS84)
     dimensions = geo_utils.bbox_to_dimensions(bbox, resolution)
 
     assert dimensions == expected_dimensions
 
 
-def test_get_image_dimensions():
+def test_get_image_dimensions() -> None:
     bbox = BBox(((111.644, 8.655), (111.7, 8.688)), CRS.WGS84)
     width = geo_utils.get_image_dimension(bbox, height=715)
     height = geo_utils.get_image_dimension(bbox, width=1202)
@@ -46,7 +50,7 @@ def test_get_image_dimensions():
     assert height == 715
 
 
-def test_bbox_transform():
+def test_bbox_transform() -> None:
     bbox = BBox(((111.644, 8.655), (111.7, 8.688)), CRS.WGS84)
     new_bbox = bbox.transform(CRS.POP_WEB)
     expected_bbox = BBox((12428153.23, 967155.41, 12434387.12, 970871.43), CRS.POP_WEB)
@@ -65,7 +69,9 @@ def test_bbox_transform():
         ((543569.807, 6062625.7678), CRS(3346), CRS.UTM_35N, (350231.496834, 6063682.846723)),
     ],
 )
-def test_transform_point(point, source_crs, target_crs, target_point):
+def test_transform_point(
+    point: Tuple[float, float], source_crs: CRS, target_crs: CRS, target_point: Tuple[float, float]
+) -> None:
     new_point = geo_utils.transform_point(point, source_crs, target_crs)
     new_source_point = geo_utils.transform_point(new_point, target_crs, source_crs)
 

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -1,5 +1,5 @@
 import copy
-from typing import Tuple, TypeVar
+from typing import Any, List, Tuple, TypeVar, Union
 
 import pytest
 import shapely.geometry
@@ -28,12 +28,12 @@ def _round_point_coords(x: float, y: float, decimals: int = 1) -> Tuple[float, f
     return round(x, decimals), round(y, decimals)
 
 
-def test_bbox_no_crs():
+def test_bbox_no_crs() -> None:
     with pytest.raises(TypeError):
-        BBox("46,13,47,20")
+        BBox("46,13,47,20")  # type: ignore[call-arg]
 
 
-def test_bbox_from_string():
+def test_bbox_from_string() -> None:
     bbox_str = "46.07, 13.23, 46.24, 13.57"
     bbox = BBox(bbox_str, CRS.WGS84)
     assert bbox.lower_left == (46.07, 13.23)
@@ -41,7 +41,7 @@ def test_bbox_from_string():
     assert bbox.crs == CRS.WGS84
 
 
-def test_bbox_from_bad_string():
+def test_bbox_from_bad_string() -> None:
     with pytest.raises(ValueError):
         # Too few coordinates
         BBox("46.07, 13.23, 46.24", CRS.WGS84)
@@ -52,7 +52,7 @@ def test_bbox_from_bad_string():
 
 
 @pytest.mark.parametrize(
-    "bbox_lst",
+    "bbox_coords",
     [
         [46.07, 13.23, 46.24, 13.57],
         [46.24, 13.23, 46.07, 13.57],
@@ -60,8 +60,8 @@ def test_bbox_from_bad_string():
         [46.24, 13.57, 46.07, 13.23],
     ],
 )
-def test_bbox_from_flat_list(bbox_lst):
-    bbox = BBox(bbox_lst, CRS.WGS84)
+def test_bbox_from_flat_list(bbox_coords: List[float]) -> None:
+    bbox = BBox(bbox_coords, CRS.WGS84)
     assert bbox.lower_left == (46.07, 13.23)
     assert bbox.upper_right == (46.24, 13.57)
     assert bbox.crs == CRS.WGS84
@@ -78,14 +78,14 @@ def test_bbox_from_flat_list(bbox_lst):
         BBox({"min_x": 46.07, "min_y": 13.23, "max_x": 46.24, "max_y": 13.57}, CRS.WGS84),
     ],
 )
-def test_bbox_different_input(bbox_input):
+def test_bbox_different_input(bbox_input: Any) -> None:
     bbox = BBox(bbox_input, CRS.WGS84)
     assert bbox.upper_right == (46.24, 13.57)
     assert bbox.lower_left == (46.07, 13.23)
     assert bbox.crs == CRS.WGS84
 
 
-def test_bbox_from_bad_dict():
+def test_bbox_from_bad_dict() -> None:
     bbox_dict = {"x1": 46.07, "y1": 13.23, "x2": 46.24, "y2": 13.57}
     with pytest.raises(KeyError):
         BBox(bbox_dict, CRS.WGS84)
@@ -99,11 +99,11 @@ def test_bbox_from_bad_dict():
         shapely.geometry.Polygon([(1, 0), (1, 1), (0, 0)]),
     ],
 )
-def test_bbox_from_shapely(bbox_input):
+def test_bbox_from_shapely(bbox_input: Any) -> None:
     assert BBox(bbox_input, CRS.WGS84) == BBox((0, 0, 1, 1), CRS.WGS84)
 
 
-def test_bbox_to_str():
+def test_bbox_to_str() -> None:
     x1, y1, x2, y2 = 45.0, 12.0, 47.0, 14.0
     crs = CRS.WGS84
     expect_str = f"{x1},{y1},{x2},{y2}"
@@ -111,21 +111,21 @@ def test_bbox_to_str():
     assert str(bbox) == expect_str
 
 
-def test_bbox_to_repr():
+def test_bbox_to_repr() -> None:
     x1, y1, x2, y2 = 45.0, 12.0, 47.0, 14.0
     bbox = BBox(((x1, y1), (x2, y2)), crs=CRS("4326"))
     expect_repr = f"BBox((({x1}, {y1}), ({x2}, {y2})), crs=CRS('4326'))"
     assert repr(bbox) == expect_repr
 
 
-def test_bbox_iter():
+def test_bbox_iter() -> None:
     bbox_lst = [46.07, 13.23, 46.24, 13.57]
     bbox = BBox(bbox_lst, CRS.WGS84)
     list_from_bbox_iter = list(bbox)
     assert list_from_bbox_iter == bbox_lst
 
 
-def test_bbox_eq():
+def test_bbox_eq() -> None:
     bbox1 = BBox([46.07, 13.23, 46.24, 13.57], CRS.WGS84)
     bbox2 = BBox(((46.24, 13.57), (46.07, 13.23)), 4326)
     bbox3 = BBox([46.07, 13.23, 46.24, 13.57], CRS.POP_WEB)
@@ -136,7 +136,7 @@ def test_bbox_eq():
     assert bbox1 is not None
 
 
-def test_transform():
+def test_transform() -> None:
     bbox1 = BBox([46.07, 13.23, 46.24, 13.57], CRS.WGS84)
     bbox2 = bbox1.transform(CRS.POP_WEB).transform(CRS.WGS84)
 
@@ -145,7 +145,7 @@ def test_transform():
     assert bbox1.crs == bbox2.crs
 
 
-def test_transform_bounds():
+def test_transform_bounds() -> None:
     bbox1 = BBox([46.07, 13.23, 46.24, 13.57], CRS.WGS84)
     utm_crs = get_utm_crs(*bbox1.middle, source_crs=CRS.WGS84)
     bbox2 = bbox1.transform_bounds(utm_crs).transform_bounds(CRS.WGS84)
@@ -154,13 +154,13 @@ def test_transform_bounds():
     assert bbox2.geometry.difference(bbox1.geometry).area > 1e-4
 
 
-def test_geometry():
+def test_geometry() -> None:
     bbox = BBox([46.07, 13.23, 46.24, 13.57], CRS.WGS84)
     assert isinstance(bbox.get_geojson(), dict)
     assert isinstance(bbox.geometry, shapely.geometry.Polygon)
 
 
-def test_buffer():
+def test_buffer() -> None:
     bbox = BBox([46.07, 13.23, 46.24, 13.57], CRS.WGS84)
 
     assert bbox != bbox.buffer(42)
@@ -180,25 +180,25 @@ def test_buffer():
 
 
 @pytest.mark.parametrize("geometry", GEOMETRY_LIST)
-def test_repr(geometry):
+def test_repr(geometry: GeoType) -> None:
     assert isinstance(repr(geometry), str)
 
 
 @pytest.mark.parametrize("geometry", GEOMETRY_LIST)
-def test_eq(geometry):
+def test_eq(geometry: GeoType) -> None:
     assert geometry == copy.deepcopy(geometry), "Deep copied object should be equal to the original"
     assert geometry is not None
 
 
 @pytest.mark.parametrize("geometry", GEOMETRY_LIST)
-def test_reverse(geometry):
+def test_reverse(geometry: GeoType) -> None:
     reversed_geometry = geometry.reverse()
     assert geometry != reversed_geometry
     assert geometry == reversed_geometry.reverse(), "Twice reversed geometry should equal the original"
 
 
 @pytest.mark.parametrize("geometry", GEOMETRY_LIST)
-def test_transform_geometry(geometry):
+def test_transform_geometry(geometry: GeoType) -> None:
     new_geometry = geometry.transform(CRS.POP_WEB)
     assert geometry != new_geometry, "Transformed geometry should be different"
 
@@ -208,7 +208,7 @@ def test_transform_geometry(geometry):
 
 
 @pytest.mark.parametrize("geometry", [GEOMETRY1, GEOMETRY2])
-def test_geojson(geometry):
+def test_geojson(geometry: Geometry) -> None:
     assert geometry == Geometry(
         geometry.geojson, geometry.crs
     ), "Transforming geometry to geojson and back should preserve it"
@@ -216,7 +216,7 @@ def test_geojson(geometry):
     assert geometry == Geometry.from_geojson(geometry.get_geojson())
 
 
-def test_geojson_parameter_with_crs():
+def test_geojson_parameter_with_crs() -> None:
     expected_without_crs = {
         "type": "Polygon",
         "coordinates": (((0.0, 0.0), (0.0, 1.0), (1.0, 1.0), (1.0, 0.0), (0.0, 0.0)),),
@@ -229,7 +229,7 @@ def test_geojson_parameter_with_crs():
     assert GEOMETRY1.get_geojson(with_crs=True) == expected_with_crs
 
 
-def test_wkt():
+def test_wkt() -> None:
     for geometry in [GEOMETRY1, GEOMETRY2]:
         assert geometry == Geometry(
             geometry.wkt, geometry.crs
@@ -239,7 +239,7 @@ def test_wkt():
 
 
 @pytest.mark.parametrize("geometry", [GEOMETRY1, GEOMETRY2, BBOX_COLLECTION])
-def test_bbox(geometry):
+def test_bbox(geometry: Union[Geometry, BBoxCollection]) -> None:
     assert geometry.bbox == BBox(geometry.geometry, geometry.crs), "Failed bbox property"
 
 

--- a/tests/test_geopedia.py
+++ b/tests/test_geopedia.py
@@ -1,6 +1,6 @@
 import datetime
 from dataclasses import dataclass
-from typing import Optional
+from typing import Any, Dict, Optional
 
 import numpy as np
 import pytest
@@ -19,7 +19,7 @@ from sentinelhub.testing_utils import test_numpy_data
 pytestmark = pytest.mark.geopedia_integration
 
 
-def test_global_session():
+def test_global_session() -> None:
     session1 = GeopediaSession(is_global=True)
     session2 = GeopediaSession(is_global=True)
     session3 = GeopediaSession(is_global=False)
@@ -28,7 +28,7 @@ def test_global_session():
     assert session1.session_id != session3.session_id, "Global and local sessions should not have the same session ID"
 
 
-def test_session_update():
+def test_session_update() -> None:
     session = GeopediaSession()
     initial_session_id = session.session_id
 
@@ -36,7 +36,7 @@ def test_session_update():
     assert session.user_id == "NO_USER", "Session user ID should be 'NO_USER'"
 
 
-def test_session_timeout():
+def test_session_timeout() -> None:
     session = GeopediaSession()
     session.SESSION_DURATION = datetime.timedelta(seconds=-1)
     initial_session_id = session.session_id
@@ -52,13 +52,13 @@ def test_session_timeout():
         dict(username="some_user", password="some_password", password_md5="md5_encoded"),
     ],
 )
-def test_false_initialization(bad_kwargs):
+def test_false_initialization(bad_kwargs: Dict[str, Any]) -> None:
     with pytest.raises(ValueError):
         GeopediaSession(**bad_kwargs)
 
 
 @pytest.mark.xfail(run=True, reason="Geopedia sometimes returns numerically wrong data")
-def test_geopedia_wms():
+def test_geopedia_wms() -> None:
     bbox = BBox(bbox=[(524358.0140363087, 6964349.630376049), (534141.9536568124, 6974133.5699965535)], crs=CRS.POP_WEB)
     gpd_request = GeopediaWmsRequest(
         layer=1917, theme="ml_aws", bbox=bbox, width=50, height=50, image_format=MimeType.PNG
@@ -71,7 +71,7 @@ def test_geopedia_wms():
     test_numpy_data(np.array(data), exp_min=0, exp_max=255, exp_mean=150.9248, exp_median=255)
 
 
-def test_geopedia_image_request(output_folder):
+def test_geopedia_image_request(output_folder: str) -> None:
     bbox = BBox(bbox=[(13520759, 437326), (13522689, 438602)], crs=CRS.POP_WEB)
     image_field_name = "Masks"
 
@@ -124,7 +124,7 @@ TEST_CASES = [
 
 
 @pytest.mark.parametrize("test_case", TEST_CASES)
-def test_iterator(test_case):
+def test_iterator(test_case: GeopediaFeatureIteratorTestCase) -> None:
     gpd_iter = GeopediaFeatureIterator(**test_case.params)
 
     for idx, feature in enumerate(gpd_iter):
@@ -139,7 +139,7 @@ def test_iterator(test_case):
 
 
 @pytest.mark.parametrize("test_case", TEST_CASES)
-def test_size_before_iteration(test_case):
+def test_size_before_iteration(test_case: GeopediaFeatureIteratorTestCase) -> None:
     if not test_case.min_features:
         return
 

--- a/tests/test_io_utils.py
+++ b/tests/test_io_utils.py
@@ -1,5 +1,6 @@
 import os
 from platform import python_implementation
+from typing import Tuple
 
 import numpy as np
 import pytest
@@ -20,7 +21,7 @@ from sentinelhub.exceptions import SHUserWarning
         ("img-16bit.jp2", 0.3041897, (1830, 1830)),
     ],
 )
-def test_img_read(input_folder, output_folder, filename, mean, shape):
+def test_img_read(input_folder: str, output_folder: str, filename: str, mean: float, shape: Tuple[int, ...]) -> None:
     is_jpeg = filename.endswith("jpg")
     img = read_data(os.path.join(input_folder, filename))
 
@@ -44,7 +45,7 @@ def test_img_read(input_folder, output_folder, filename, mean, shape):
         assert np.array_equal(img, new_img), "Original and saved image are not the same"
 
 
-def test_read_tar_with_folder(input_folder):
+def test_read_tar_with_folder(input_folder: str) -> None:
     path = os.path.join(input_folder, "tar-folder.tar")
     data = read_data(path)
 

--- a/tests/test_time_utils.py
+++ b/tests/test_time_utils.py
@@ -2,6 +2,7 @@
 Unit tests for time utility functions
 """
 import datetime as dt
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import dateutil.tz
 import pytest
@@ -34,7 +35,7 @@ DELTAS = [
     "time_input,is_valid",
     [("2017-01-32", False), ("2017-13-1", False), ("2017-02-29", False), ("2020-02-29", True), ("2020-02-30", False)],
 )
-def test_is_valid_time(time_input, is_valid):
+def test_is_valid_time(time_input: str, is_valid: bool) -> None:
     assert time_utils.is_valid_time(time_input) is is_valid
 
 
@@ -55,7 +56,7 @@ def test_is_valid_time(time_input, is_valid):
         (TEST_DATE, {"force_datetime": True}, dt.datetime(year=2015, month=4, day=12)),
     ],
 )
-def test_parse_time(time_input, params, expected_output):
+def test_parse_time(time_input: Any, params: Dict[str, Any], expected_output: Optional[dt.date]) -> None:
     parsed_time = time_utils.parse_time(time_input, **params)
     assert parsed_time == expected_output
 
@@ -77,7 +78,9 @@ def test_parse_time(time_input, params, expected_output):
         ((None, TEST_DATE), {"allow_undefined": True}, (None, TEST_TIME_END)),
     ],
 )
-def test_parse_time_interval(time_input, params, expected_output):
+def test_parse_time_interval(
+    time_input: Any, params: Dict[str, Any], expected_output: Tuple[Optional[dt.datetime], Optional[dt.datetime]]
+) -> None:
     parsed_interval = time_utils.parse_time_interval(time_input, **params)
     assert parsed_interval == expected_output
 
@@ -101,7 +104,7 @@ def test_parse_time_interval(time_input, params, expected_output):
         ((None, TEST_DATETIME), {}, ("..", "2015-04-12T12:32:14")),
     ],
 )
-def test_serialize_time(time_input, params, expected_output):
+def test_serialize_time(time_input: Any, params: Dict[str, Any], expected_output: Union[str, Tuple[str, ...]]) -> None:
     serialized_result = time_utils.serialize_time(time_input, **params)
     assert serialized_result == expected_output
 
@@ -110,7 +113,7 @@ def test_serialize_time(time_input, params, expected_output):
     "input_date,input_time,expected_output",
     [(TEST_DATE, None, TEST_TIME_START), (TEST_DATE, dt.time(hour=12, minute=32, second=14), TEST_DATETIME)],
 )
-def test_date_to_datetime(input_date, input_time, expected_output):
+def test_date_to_datetime(input_date: dt.date, input_time: Optional[dt.time], expected_output: dt.datetime) -> None:
     result_datetime = time_utils.date_to_datetime(input_date, time=input_time)
     assert result_datetime == expected_output
 
@@ -126,6 +129,6 @@ def test_date_to_datetime(input_date, input_time, expected_output):
         ([TIMES[0], TIMES[3], TIMES[4]], DELTAS[3], [TIMES[0], TIMES[4]]),
     ],
 )
-def test_filter_times(input_timestamps, time_difference, expected_result):
+def test_filter_times(input_timestamps: Any, time_difference: dt.timedelta, expected_result: List[dt.date]) -> None:
     result = time_utils.filter_times(input_timestamps, time_difference)
     assert result == expected_result


### PR DESCRIPTION
Another thing I wanted to finish before I left - to add type hints to all tests.

On one hand it seems redundant to have e.g. a return type ` -> None:` in each test but a general benefit of having type hints is that now if you run mypy on tests it will show a wide range of minor typing issues. Some of them could just be suppressed but some of them actually suggest beneficial improvements in the package. So in the future, you can try to improve some of them.