### PR TITLE
Update BYOC tests now that ingestion information is returned

### DIFF
--- a/tests/api/test_byoc.py
+++ b/tests/api/test_byoc.py
@@ -96,7 +96,7 @@ def tile_fixture() -> JsonDict:
         "created": "2020-06-22T12:33:36.081000Z",
         "sensingTime": None,
         "additionalData": {"minMetersPerPixel": 10.0, "maxMetersPerPixel": 160.0},
-        "other_data": {"ingestionStart": "2022-11-07T14:51:57.381758Z"},
+        "ingestionStart": "2022-11-07T14:51:57.381758Z",
     }
 
 
@@ -148,7 +148,7 @@ def test_byoc_tile_other_data(tile: JsonDict) -> None:
 
     tile_object = ByocTile.from_dict(tile)
     assert isinstance(tile_object, ByocTile)
-    assert tile_object.other_data == {"FakeParam": "x"}
+    assert tile_object.other_data["FakeParam"] == "x"
 
     tile_dict = tile_object.to_dict()
     assert tile == tile_dict

--- a/tests/api/test_byoc.py
+++ b/tests/api/test_byoc.py
@@ -96,6 +96,7 @@ def tile_fixture() -> JsonDict:
         "created": "2020-06-22T12:33:36.081000Z",
         "sensingTime": None,
         "additionalData": {"minMetersPerPixel": 10.0, "maxMetersPerPixel": 160.0},
+        "other_data": {"ingestionStart": "2022-11-07T14:51:57.381758Z"},
     }
 
 


### PR DESCRIPTION
in a recent update they now return additional information about BYOC tiles, the tests have been updated to reflect that.