### PR TITLE
BYOC Example: Replaced ISO parsing with dateutil

### DIFF
--- a/examples/byoc_request.ipynb
+++ b/examples/byoc_request.ipynb
@@ -30,6 +30,7 @@
     "\n",
     "# Utilities\n",
     "import boto3\n",
+    "import dateutil\n",
     "import geopandas as gpd\n",
     "import matplotlib.pyplot as plt\n",
     "import pandas as pd\n",
@@ -1256,7 +1257,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "tile_time = dt.datetime.fromisoformat(tiles[0][\"sensingTime\"])"
+    "tile_time = dateutil.parser.parse(tiles[0][\"sensingTime\"])"
    ]
   },
   {


### PR DESCRIPTION
`datetime.datetime.fromisoformat()` can not parse all datetime strings compatible with ISO8601. It for example does not accept `Z` to specify UTZ. 

This was replaced with `dateutil.parser.parse()` which is also used in the package to parse dt strings.