### PR TITLE
Rename `type_utils` to `types`

### DIFF
--- a/sentinelhub/api/base.py
+++ b/sentinelhub/api/base.py
@@ -17,7 +17,7 @@ from ..config import SHConfig
 from ..data_collections import DataCollection
 from ..download.sentinelhub_client import SentinelHubDownloadClient
 from ..exceptions import MissingDataInRequestException
-from ..type_utils import JsonDict
+from ..types import JsonDict
 from .utils import datetime_config, remove_undefined
 
 if sys.version_info < (3, 8):

--- a/sentinelhub/api/batch/base.py
+++ b/sentinelhub/api/batch/base.py
@@ -6,7 +6,7 @@ from enum import Enum
 from typing import Generic, Iterable, Optional, Sequence, Type, TypeVar, Union
 
 from ...constants import RequestType
-from ...type_utils import Json, JsonDict
+from ...types import Json, JsonDict
 from ..base import SentinelHubService
 
 BatchRequestType = TypeVar("BatchRequestType", bound="BaseBatchRequest")  # pylint: disable=invalid-name

--- a/sentinelhub/api/batch/process.py
+++ b/sentinelhub/api/batch/process.py
@@ -15,7 +15,7 @@ from dataclasses_json import dataclass_json
 from ...constants import RequestType
 from ...data_collections import DataCollection
 from ...geometry import CRS, BBox, Geometry
-from ...type_utils import Json, JsonDict
+from ...types import Json, JsonDict
 from ..base import BaseCollection, SentinelHubFeatureIterator
 from ..process import SentinelHubRequest
 from ..utils import datetime_config, enum_config, remove_undefined

--- a/sentinelhub/api/batch/statistical.py
+++ b/sentinelhub/api/batch/statistical.py
@@ -12,7 +12,7 @@ from dataclasses_json import CatchAll, LetterCase, Undefined
 from dataclasses_json import config as dataclass_config
 from dataclasses_json import dataclass_json
 
-from ...type_utils import Json, JsonDict
+from ...types import Json, JsonDict
 from ..base_request import InputDataDict
 from ..statistical import SentinelHubStatistical
 from ..utils import datetime_config, enum_config, remove_undefined

--- a/sentinelhub/api/batch/utils.py
+++ b/sentinelhub/api/batch/utils.py
@@ -9,7 +9,7 @@ from typing import DefaultDict, List, Optional, Union
 from tqdm.auto import tqdm
 
 from ...config import SHConfig
-from ...type_utils import JsonDict
+from ...types import JsonDict
 from .base import BatchRequestStatus
 from .process import BatchRequest, BatchTileStatus, SentinelHubBatch
 from .statistical import BatchStatisticalRequest, SentinelHubBatchStatistical

--- a/sentinelhub/api/byoc.py
+++ b/sentinelhub/api/byoc.py
@@ -13,7 +13,7 @@ from dataclasses_json import dataclass_json
 from ..constants import MimeType, RequestType
 from ..data_collections import DataCollection
 from ..geometry import Geometry
-from ..type_utils import Json, JsonDict
+from ..types import Json, JsonDict
 from .base import BaseCollection, SentinelHubFeatureIterator, SentinelHubService
 from .utils import datetime_config, geometry_config, remove_undefined
 

--- a/sentinelhub/api/catalog.py
+++ b/sentinelhub/api/catalog.py
@@ -9,7 +9,7 @@ from ..base import FeatureIterator
 from ..data_collections import DataCollection, OrbitDirection
 from ..geometry import CRS, BBox, Geometry
 from ..time_utils import parse_time, parse_time_interval, serialize_time
-from ..type_utils import JsonDict, RawTimeIntervalType, RawTimeType
+from ..types import JsonDict, RawTimeIntervalType, RawTimeType
 from .base import SentinelHubService
 from .utils import remove_undefined
 

--- a/sentinelhub/api/opensearch.py
+++ b/sentinelhub/api/opensearch.py
@@ -14,7 +14,7 @@ from ..constants import CRS
 from ..download import DownloadClient
 from ..geometry import BBox
 from ..time_utils import RawTimeIntervalType, RawTimeType, parse_time, parse_time_interval, serialize_time
-from ..type_utils import JsonDict
+from ..types import JsonDict
 
 LOGGER = logging.getLogger(__name__)
 

--- a/sentinelhub/api/process.py
+++ b/sentinelhub/api/process.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 from ..constants import MimeType
 from ..download import SentinelHubDownloadClient
 from ..geometry import BBox, Geometry
-from ..type_utils import JsonDict
+from ..types import JsonDict
 from .base_request import InputDataDict, SentinelHubBaseApiRequest
 from .utils import _update_other_args
 

--- a/sentinelhub/api/statistical.py
+++ b/sentinelhub/api/statistical.py
@@ -8,7 +8,7 @@ from ..constants import MimeType
 from ..download.sentinelhub_statistical_client import SentinelHubStatisticalDownloadClient
 from ..geometry import BBox, Geometry
 from ..time_utils import parse_time_interval, serialize_time
-from ..type_utils import JsonDict, RawTimeIntervalType
+from ..types import JsonDict, RawTimeIntervalType
 from .base_request import InputDataDict, SentinelHubBaseApiRequest
 from .utils import _update_other_args, remove_undefined
 

--- a/sentinelhub/api/wfs.py
+++ b/sentinelhub/api/wfs.py
@@ -15,7 +15,7 @@ from ..data_collections import DataCollection
 from ..download import SentinelHubDownloadClient
 from ..geometry import BBox
 from ..time_utils import parse_time, parse_time_interval, serialize_time
-from ..type_utils import JsonDict, RawTimeIntervalType, RawTimeType
+from ..types import JsonDict, RawTimeIntervalType, RawTimeType
 
 
 class WebFeatureService(FeatureIterator[JsonDict]):

--- a/sentinelhub/areas.py
+++ b/sentinelhub/areas.py
@@ -20,7 +20,7 @@ from .constants import CRS
 from .data_collections import DataCollection
 from .geo_utils import transform_point
 from .geometry import BBox, BBoxCollection, Geometry, _BaseGeometry
-from .type_utils import JsonDict
+from .types import JsonDict
 
 T = TypeVar("T", float, int)
 

--- a/sentinelhub/base.py
+++ b/sentinelhub/base.py
@@ -8,7 +8,7 @@ from typing import Any, Callable, Generic, Iterable, List, Optional, Tuple, Type
 
 from .config import SHConfig
 from .download import DownloadClient, DownloadRequest
-from .type_utils import JsonDict
+from .types import JsonDict
 
 _T = TypeVar("_T")
 

--- a/sentinelhub/data_utils.py
+++ b/sentinelhub/data_utils.py
@@ -4,7 +4,7 @@ Module with statistics to dataframe transformation.
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 from .time_utils import parse_time
-from .type_utils import JsonDict
+from .types import JsonDict
 
 _PANDAS_IMPORT_MESSAGE = (
     "To use this function you need to install the `pandas` library, which is not a dependency of sentinelhub-py."

--- a/sentinelhub/download/client.py
+++ b/sentinelhub/download/client.py
@@ -22,7 +22,7 @@ from ..exceptions import (
     SHRuntimeWarning,
 )
 from ..io_utils import read_data
-from ..type_utils import JsonDict
+from ..types import JsonDict
 from .handlers import fail_user_errors, retry_temporary_errors
 from .models import DownloadRequest, DownloadResponse
 

--- a/sentinelhub/download/models.py
+++ b/sentinelhub/download/models.py
@@ -19,7 +19,7 @@ from ..constants import MimeType, RequestType
 from ..decoding import decode_data
 from ..exceptions import SHRuntimeWarning
 from ..io_utils import read_data, write_data
-from ..type_utils import JsonDict
+from ..types import JsonDict
 
 
 @dataclass

--- a/sentinelhub/download/rate_limit.py
+++ b/sentinelhub/download/rate_limit.py
@@ -5,7 +5,7 @@ import time
 from enum import Enum
 from typing import Union
 
-from ..type_utils import JsonDict
+from ..types import JsonDict
 
 
 class PolicyType(Enum):

--- a/sentinelhub/download/sentinelhub_client.py
+++ b/sentinelhub/download/sentinelhub_client.py
@@ -13,7 +13,7 @@ from requests import Response
 from ..config import SHConfig
 from ..constants import SHConstants
 from ..exceptions import SHRateLimitWarning, SHRuntimeWarning
-from ..type_utils import JsonDict
+from ..types import JsonDict
 from .client import DownloadClient
 from .handlers import fail_user_errors, retry_temporary_errors
 from .models import DownloadRequest, DownloadResponse

--- a/sentinelhub/download/sentinelhub_statistical_client.py
+++ b/sentinelhub/download/sentinelhub_statistical_client.py
@@ -8,7 +8,7 @@ import logging
 from typing import Any, Dict
 
 from ..exceptions import DownloadFailedException
-from ..type_utils import JsonDict
+from ..types import JsonDict
 from .models import DownloadRequest, DownloadResponse
 from .sentinelhub_client import SentinelHubDownloadClient
 

--- a/sentinelhub/download/session.py
+++ b/sentinelhub/download/session.py
@@ -21,7 +21,7 @@ from ..constants import SHConstants
 from ..download.handlers import fail_user_errors, retry_temporary_errors
 from ..download.models import DownloadRequest
 from ..exceptions import SHUserWarning
-from ..type_utils import JsonDict
+from ..types import JsonDict
 
 if sys.version_info < (3, 8):
     from shared_memory import SharedMemory

--- a/sentinelhub/geopedia/core.py
+++ b/sentinelhub/geopedia/core.py
@@ -17,7 +17,7 @@ from ..config import SHConfig
 from ..constants import CRS, MimeType
 from ..download import DownloadClient, DownloadRequest
 from ..geometry import BBox
-from ..type_utils import JsonDict
+from ..types import JsonDict
 
 if TYPE_CHECKING:
     from .request import GeopediaImageRequest

--- a/sentinelhub/io_utils.py
+++ b/sentinelhub/io_utils.py
@@ -17,7 +17,7 @@ from PIL import Image
 from .constants import MimeType
 from .decoding import decode_image_with_pillow, decode_jp2_image, decode_tar, get_data_format
 from .exceptions import SHUserWarning
-from .type_utils import Json
+from .types import Json
 
 LOGGER = logging.getLogger(__name__)
 

--- a/sentinelhub/time_utils.py
+++ b/sentinelhub/time_utils.py
@@ -7,7 +7,7 @@ from typing import Any, Iterable, List, Optional, Tuple, TypeVar, Union, overloa
 import dateutil.parser
 import dateutil.tz
 
-from .type_utils import RawTimeIntervalType, RawTimeType
+from .types import RawTimeIntervalType, RawTimeType
 
 TimeType = TypeVar("TimeType", dt.date, dt.datetime)  # pylint: disable=invalid-name
 

--- a/sentinelhub/type_utils.py
+++ b/sentinelhub/type_utils.py
@@ -5,7 +5,7 @@ from .exceptions import SHDeprecationWarning
 from .types import *  # noqa # pylint: disable=wildcard-import,unused-wildcard-import
 
 warn(
-    "The module `sentinelhub.types` is deprecated, use `sentinelhub.types` instead.",
+    "The module `sentinelhub.type_utils` is deprecated, use `sentinelhub.types` instead.",
     category=SHDeprecationWarning,
     stacklevel=2,
 )

--- a/sentinelhub/type_utils.py
+++ b/sentinelhub/type_utils.py
@@ -1,10 +1,11 @@
-"""
-Module with custom types and utilities.
-"""
-import datetime as dt
-from typing import Any, Dict, Tuple, Union
+"""Deprecated module for types, moved to `sentinelhub.types`."""
+from warnings import warn
 
-RawTimeType = Union[None, str, dt.date]
-RawTimeIntervalType = Tuple[RawTimeType, RawTimeType]
-JsonDict = Dict[str, Any]
-Json = Union[JsonDict, list, str, float, int, None]
+from .exceptions import SHDeprecationWarning
+from .types import *  # noqa # pylint: disable=wildcard-import,unused-wildcard-import
+
+warn(
+    "The module `sentinelhub.types` is deprecated, use `sentinelhub.types` instead.",
+    category=SHDeprecationWarning,
+    stacklevel=2,
+)

--- a/sentinelhub/types.py
+++ b/sentinelhub/types.py
@@ -1,0 +1,8 @@
+"""Module with custom types and utilities used in sentinelhub-py."""
+import datetime as dt
+from typing import Any, Dict, Tuple, Union
+
+RawTimeType = Union[None, str, dt.date]
+RawTimeIntervalType = Tuple[RawTimeType, RawTimeType]
+JsonDict = Dict[str, Any]
+Json = Union[JsonDict, list, str, float, int, None]

--- a/tests/api/test_byoc.py
+++ b/tests/api/test_byoc.py
@@ -9,7 +9,7 @@ import pytest
 from requests_mock import Mocker
 
 from sentinelhub import ByocCollection, ByocTile, DownloadFailedException, SentinelHubBYOC, SHConfig
-from sentinelhub.type_utils import JsonDict
+from sentinelhub.types import JsonDict
 
 pytestmark = pytest.mark.sh_integration
 

--- a/tests/api/test_statistical.py
+++ b/tests/api/test_statistical.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, Optional, Tuple
 import pytest
 
 from sentinelhub import CRS, BBox, DataCollection, Geometry, SentinelHubStatistical
-from sentinelhub.type_utils import JsonDict
+from sentinelhub.types import JsonDict
 
 EVALSCRIPT = """
 //VERSION=3

--- a/tests/aws/test_batch.py
+++ b/tests/aws/test_batch.py
@@ -13,7 +13,7 @@ from pytest_mock import MockerFixture
 from sentinelhub import BatchRequestStatus, BatchStatisticalRequest, SHConfig
 from sentinelhub.api.batch.statistical import BatchStatisticalRequestType
 from sentinelhub.aws import AwsBatchResults
-from sentinelhub.type_utils import JsonDict
+from sentinelhub.types import JsonDict
 
 
 class BatchInputType(Enum):

--- a/tests/download/test_models.py
+++ b/tests/download/test_models.py
@@ -12,7 +12,7 @@ import pytest
 from sentinelhub import DownloadRequest, MimeType
 from sentinelhub.download.models import DownloadResponse
 from sentinelhub.exceptions import SHRuntimeWarning
-from sentinelhub.type_utils import JsonDict
+from sentinelhub.types import JsonDict
 
 
 def test_download_request() -> None:

--- a/tests/download/test_rate_limit.py
+++ b/tests/download/test_rate_limit.py
@@ -13,7 +13,7 @@ import pytest
 from pytest import approx
 
 from sentinelhub.download.rate_limit import PolicyBucket, PolicyType, SentinelHubRateLimit
-from sentinelhub.type_utils import JsonDict
+from sentinelhub.types import JsonDict
 
 
 class DummyService:

--- a/tests/download/test_session.py
+++ b/tests/download/test_session.py
@@ -9,7 +9,7 @@ from requests_mock import Mocker
 from sentinelhub import SentinelHubSession, SHConfig, __version__
 from sentinelhub.download import SessionSharing, SessionSharingThread, collect_shared_session
 from sentinelhub.exceptions import DownloadFailedException, SHUserWarning
-from sentinelhub.type_utils import JsonDict
+from sentinelhub.types import JsonDict
 
 
 @pytest.fixture(name="fake_config")


### PR DESCRIPTION
Renames the module and makes the other emit a deprecation warning when used.