### PR TITLE
Add dataFilter defaults of {} to batch statistical

### DIFF
--- a/sentinelhub/api/batch/statistical.py
+++ b/sentinelhub/api/batch/statistical.py
@@ -6,7 +6,7 @@ import datetime as dt
 import logging
 import sys
 from dataclasses import dataclass, field
-from typing import Any, List, Optional, Union
+from typing import Any, Optional, Sequence, Union
 
 from dataclasses_json import CatchAll, LetterCase, Undefined
 from dataclasses_json import config as dataclass_config
@@ -59,7 +59,7 @@ class SentinelHubBatchStatistical(BaseBatchClient["BatchStatisticalRequest"]):
         self,
         *,
         input_features: AccessSpecification,
-        input_data: List[Union[JsonDict, InputDataDict]],
+        input_data: Sequence[Union[JsonDict, InputDataDict]],
         aggregation: JsonDict,
         calculations: Optional[JsonDict],
         output: AccessSpecification,
@@ -71,8 +71,14 @@ class SentinelHubBatchStatistical(BaseBatchClient["BatchStatisticalRequest"]):
         <https://docs.sentinel-hub.com/api/latest/reference/#operation/createNewBatchStatisticsRequest>`__
         """
 
+        # Data filter has to be set to {} if not provided. Ensure we do not mutate original data.
+        requested_data = list(input_data)
+        for i, data_request_dict in enumerate(requested_data):
+            if "dataFilter" not in data_request_dict:
+                requested_data[i] = {"dataFilter": {}, **data_request_dict}
+
         payload = {
-            "input": {"features": input_features, "data": input_data},
+            "input": {"features": input_features, "data": requested_data},
             "aggregation": aggregation,
             "calculations": calculations,
             "output": output,

--- a/sentinelhub/api/statistical.py
+++ b/sentinelhub/api/statistical.py
@@ -2,7 +2,7 @@
 Implementation of
 `Sentinel Hub Statistical API interface <https://docs.sentinel-hub.com/api/latest/api/statistical/>`__.
 """
-from typing import Any, List, Optional, Tuple, Union
+from typing import Any, Optional, Sequence, Tuple, Union
 
 from ..constants import MimeType
 from ..download.sentinelhub_statistical_client import SentinelHubStatisticalDownloadClient
@@ -25,7 +25,7 @@ class SentinelHubStatistical(SentinelHubBaseApiRequest):
     def __init__(
         self,
         aggregation: JsonDict,
-        input_data: List[Union[JsonDict, InputDataDict]],
+        input_data: Sequence[Union[JsonDict, InputDataDict]],
         bbox: Optional[BBox] = None,
         geometry: Optional[Geometry] = None,
         calculations: Optional[JsonDict] = None,
@@ -60,7 +60,7 @@ class SentinelHubStatistical(SentinelHubBaseApiRequest):
     @staticmethod
     def body(
         request_bounds: JsonDict,
-        request_data: List[JsonDict],
+        request_data: Sequence[JsonDict],
         aggregation: JsonDict,
         calculations: Optional[JsonDict],
         other_args: Optional[JsonDict] = None,
@@ -75,13 +75,13 @@ class SentinelHubStatistical(SentinelHubBaseApiRequest):
             by it.
         :returns: Request payload dictionary
         """
-        # Some parts of the payload have to be defined:
-        for input_data_payload in request_data:
-            if "dataFilter" not in input_data_payload:
-                input_data_payload["dataFilter"] = {}
+        requested_data = list(request_data)
+        for i, data_request_dict in enumerate(requested_data):
+            if "dataFilter" not in data_request_dict:
+                requested_data[i] = {"dataFilter": {}, **data_request_dict}
 
         request_body = {
-            "input": {"bounds": request_bounds, "data": request_data},
+            "input": {"bounds": request_bounds, "data": requested_data},
             "aggregation": aggregation,
             "calculations": calculations,
         }


### PR DESCRIPTION
The regular statistical API already did that. However it did that in a mutable way, which we now avoid by copying elements that are to be adjusted.