### PR TITLE
reduce or specialize type: ignore comments

### DIFF
--- a/sentinelhub/api/batch/process.py
+++ b/sentinelhub/api/batch/process.py
@@ -52,7 +52,7 @@ class SentinelHubBatch(BaseBatchClient):
 
     def create(
         self,
-        sentinelhub_request: Union[SentinelHubRequest, Dict[str, Any]],
+        sentinelhub_request: Union[SentinelHubRequest, JsonDict],
         tiling_grid: Dict[str, Any],
         output: Optional[Dict[str, Any]] = None,
         bucket_name: Optional[str] = None,
@@ -75,17 +75,20 @@ class SentinelHubBatch(BaseBatchClient):
         :param kwargs: Any other arguments to be added to a dictionary of parameters.
         :return: An instance of `SentinelHubBatch` object that represents a newly created batch request.
         """
-        if isinstance(sentinelhub_request, SentinelHubRequest):
-            sentinelhub_request = sentinelhub_request.download_list[0].post_values  # type: ignore[assignment]
 
-        if not isinstance(sentinelhub_request, dict):
+        if isinstance(sentinelhub_request, SentinelHubRequest):
+            request_dict = sentinelhub_request.download_list[0].post_values
+        else:
+            request_dict = sentinelhub_request
+
+        if not isinstance(request_dict, dict):
             raise ValueError(
                 "Parameter sentinelhub_request should be an instance of SentinelHubRequest or a "
                 "dictionary with a request payload"
             )
 
         payload = {
-            "processRequest": sentinelhub_request,
+            "processRequest": request_dict,
             "tilingGrid": tiling_grid,
             "output": output,
             "bucketName": bucket_name,

--- a/sentinelhub/api/byoc.py
+++ b/sentinelhub/api/byoc.py
@@ -269,7 +269,7 @@ class SentinelHubBYOC(SentinelHubService):
     def _to_dict(data: object) -> dict:
         """Constructs dict from an object (either dataclass or dict)"""
         if isinstance(data, (ByocCollection, ByocTile, ByocCollectionAdditionalData, ByocCollectionBand)):
-            return data.to_dict()  # type: ignore[union-attr]
+            return data.to_dict()  # type: ignore[union-attr] # to_dict method comes from decorators and is undetectable
         if isinstance(data, dict):
             return data
         raise ValueError(f"Expected either a data class (e.g., ByocCollection and similar) or a dict, got {data}.")

--- a/sentinelhub/api/catalog.py
+++ b/sentinelhub/api/catalog.py
@@ -2,21 +2,15 @@
 A client interface for `Sentinel Hub Catalog API <https://docs.sentinel-hub.com/api/latest/api/catalog>`__.
 """
 import datetime as dt
-import sys
 from typing import Any, Dict, Iterable, List, Optional, Union
 
 from ..base import FeatureIterator
 from ..data_collections import DataCollection, OrbitDirection
 from ..geometry import CRS, BBox, Geometry
 from ..time_utils import parse_time, parse_time_interval, serialize_time
-from ..types import JsonDict, RawTimeIntervalType, RawTimeType
+from ..types import JsonDict, Literal, RawTimeIntervalType, RawTimeType
 from .base import SentinelHubService
 from .utils import remove_undefined
-
-if sys.version_info < (3, 8):
-    from typing_extensions import Literal
-else:
-    from typing import Literal  # pylint: disable=ungrouped-imports
 
 
 class SentinelHubCatalog(SentinelHubService):
@@ -256,7 +250,7 @@ class CatalogSearchIterator(FeatureIterator[JsonDict]):
 
         :return: A list of sensing times
         """
-        return [parse_time(feature["properties"]["datetime"]) for feature in self]  # type: ignore[misc]
+        return [parse_time(feature["properties"]["datetime"], force_datetime=True) for feature in self]
 
     def get_geometries(self) -> List[Geometry]:
         """Provides features geometries

--- a/sentinelhub/api/fis.py
+++ b/sentinelhub/api/fis.py
@@ -66,9 +66,11 @@ class FisRequest(OgcRequest):
         self.bins = bins
         self.histogram_type = HistogramType(histogram_type) if histogram_type else None
 
-        super().__init__(bbox=None, layer=layer, time=time, service_type=ServiceType.FIS, **kwargs)  # type: ignore
+        super().__init__(
+            bbox=None, layer=layer, time=time, service_type=ServiceType.FIS, **kwargs  # type: ignore[arg-type]
+        )
 
-    def create_request(self) -> None:  # type: ignore
+    def create_request(self) -> None:  # type: ignore[override]
         """Set download requests
 
         Create a list of DownloadRequests for all Sentinel-2 acquisitions within request's time interval and
@@ -102,7 +104,7 @@ class _FisService(OgcImageService):
 
         super().__init__(*args, **kwargs)
 
-    def get_request(self, request: FisRequest) -> List[DownloadRequest]:  # type: ignore
+    def get_request(self, request: FisRequest) -> List[DownloadRequest]:  # type: ignore[override]
         """Get download requests
 
         Create a list of DownloadRequests for all Sentinel-2 acquisitions within request's time interval and

--- a/sentinelhub/api/ogc.py
+++ b/sentinelhub/api/ogc.py
@@ -317,11 +317,11 @@ class OgcImageService:
         if request.service_type in (ServiceType.WMS, ServiceType.WCS):
             params = {**params, **self._get_wms_wcs_url_parameters(request, date)}
         if request.service_type is ServiceType.WMS:
-            params = {**params, **self._get_wms_url_parameters(request, size_x, size_y)}  # type: ignore
+            params = {**params, **self._get_wms_url_parameters(request, size_x, size_y)}  # type: ignore[arg-type]
         elif request.service_type is ServiceType.WCS:
-            params = {**params, **self._get_wcs_url_parameters(request, size_x, size_y)}  # type: ignore
+            params = {**params, **self._get_wcs_url_parameters(request, size_x, size_y)}  # type: ignore[arg-type]
         elif request.service_type is ServiceType.FIS:
-            params = {**params, **self._get_fis_parameters(request, geometry)}  # type: ignore
+            params = {**params, **self._get_fis_parameters(request, geometry)}  # type: ignore[arg-type]
 
         return f"{url}/{authority}?{urlencode(params)}"
 
@@ -331,7 +331,7 @@ class OgcImageService:
         :param request: OGC-type request with specified bounding box, cloud coverage for specific product.
         :return: base string for url to Sentinel Hub's OGC service for this product.
         """
-        url = f"{self._base_url}/{request.service_type.value}"  # type: ignore
+        url = f"{self._base_url}/{request.service_type.value}"  # type: ignore[union-attr]
 
         if hasattr(request, "data_collection") and request.data_collection.service_url:
             url = url.replace(self.config.sh_base_url, request.data_collection.service_url)
@@ -345,7 +345,7 @@ class OgcImageService:
         :param request: OGC-type request with specified bounding box, cloud coverage for specific product.
         :return: dictionary with parameters
         """
-        params = {"SERVICE": request.service_type.value, "WARNINGS": False}  # type: ignore
+        params = {"SERVICE": request.service_type.value, "WARNINGS": False}  # type: ignore[union-attr]
 
         if hasattr(request, "maxcc"):
             params["MAXCC"] = 100.0 * request.maxcc
@@ -446,7 +446,7 @@ class OgcImageService:
         params = {
             "CRS": CRS.ogc_string(geometry.crs),
             "LAYER": request.layer,
-            "RESOLUTION": request.resolution,  # type: ignore
+            "RESOLUTION": request.resolution,  # type: ignore[attr-defined]
             "TIME": f"{start_time}/{end_time}",
         }
 
@@ -462,11 +462,11 @@ class OgcImageService:
         else:
             params["BBOX"] = str(geometry)
 
-        if request.bins:  # type: ignore
-            params["BINS"] = request.bins  # type: ignore
+        if request.bins:  # type: ignore[attr-defined]
+            params["BINS"] = request.bins  # type: ignore[attr-defined]
 
-        if request.histogram_type:  # type: ignore
-            params["TYPE"] = request.histogram_type.value  # type: ignore
+        if request.histogram_type:  # type: ignore[attr-defined]
+            params["TYPE"] = request.histogram_type.value  # type: ignore[attr-defined]
 
         return params
 
@@ -499,10 +499,10 @@ class OgcImageService:
             self.wfs_iterator = request.wfs_iterator
 
         dates = self.wfs_iterator.get_dates()
-        dates = filter_times(dates, request.time_difference)  # type: ignore
+        dates = filter_times(dates, request.time_difference)  # type: ignore[type-var]
 
         LOGGER.debug("Initializing requests for dates: %s", dates)
-        return dates  # type: ignore
+        return dates  # type: ignore[return-value]
 
     @staticmethod
     def get_image_dimensions(request: OgcRequest) -> Tuple[Union[int, str], Union[int, str]]:
@@ -514,14 +514,14 @@ class OgcImageService:
         if request.service_type is ServiceType.WCS or (
             isinstance(request.size_x, int) and isinstance(request.size_y, int)
         ):
-            return request.size_x, request.size_y  # type: ignore
+            return request.size_x, request.size_y  # type: ignore[return-value]
         if not isinstance(request.size_x, int) and not isinstance(request.size_y, int):
             raise ValueError("At least one of parameters 'width' and 'height' must have an integer value")
         missing_dimension = get_image_dimension(
-            request.bbox, width=request.size_x, height=request.size_y  # type: ignore
+            request.bbox, width=request.size_x, height=request.size_y  # type: ignore[arg-type]
         )
         if request.size_x is None:
-            return missing_dimension, request.size_y  # type: ignore
+            return missing_dimension, request.size_y  # type: ignore[return-value]
         if request.size_y is None:
             return request.size_x, missing_dimension
         raise ValueError("Parameters 'width' and 'height' must be integers or None")

--- a/sentinelhub/api/opensearch.py
+++ b/sentinelhub/api/opensearch.py
@@ -102,7 +102,7 @@ def get_area_dates(bbox: BBox, date_interval: RawTimeIntervalType, maxcc: Option
     """
 
     area_info = get_area_info(bbox, date_interval, maxcc=maxcc)
-    return sorted({parse_time(tile_info["properties"]["startDate"]) for tile_info in area_info})  # type: ignore
+    return sorted({parse_time(tile_info["properties"]["startDate"]) for tile_info in area_info})
 
 
 def reduce_by_maxcc(result_list: Iterable[JsonDict], maxcc: float) -> List[JsonDict]:

--- a/sentinelhub/api/utils.py
+++ b/sentinelhub/api/utils.py
@@ -16,7 +16,6 @@ datetime_config = dataclass_config(
     letter_case=LetterCase.CAMEL,
 )
 
-
 geometry_config = dataclass_config(
     encoder=Geometry.get_geojson,
     decoder=lambda geojson: Geometry.from_geojson(geojson) if geojson else None,

--- a/sentinelhub/areas.py
+++ b/sentinelhub/areas.py
@@ -455,7 +455,7 @@ class CustomGridSplitter(AreaSplitter):
         return bbox_list, info_list
 
 
-class BaseUtmSplitter(AreaSplitter):
+class BaseUtmSplitter(AreaSplitter, metaclass=ABCMeta):
     """Base splitter that returns bboxes of fixed size aligned to UTM zones or UTM grid tiles as defined by the MGRS
 
     The generated bounding box grid will have coordinates in form of
@@ -485,7 +485,7 @@ class BaseUtmSplitter(AreaSplitter):
 
     @abstractmethod
     def _get_utm_polygons(self) -> List[Tuple[BaseGeometry, Dict[str, Any]]]:
-        raise NotImplementedError
+        """Find UTM grid zones overlapping with input area shape."""
 
     @staticmethod
     def _get_utm_from_props(utm_dict: Dict[str, Any]) -> CRS:
@@ -556,7 +556,9 @@ class BaseUtmSplitter(AreaSplitter):
 
         return bbox_list, info_list
 
-    def get_bbox_list(self, buffer: Union[None, float, Tuple[float, float]] = None) -> List[BBox]:  # type: ignore
+    def get_bbox_list(  # type: ignore[override]
+        self, buffer: Union[None, float, Tuple[float, float]] = None
+    ) -> List[BBox]:
         """Get list of bounding boxes.
 
         The CRS is fixed to the computed UTM CRS. This BBox splitter does not support reducing size of output

--- a/sentinelhub/aws/data.py
+++ b/sentinelhub/aws/data.py
@@ -496,7 +496,7 @@ class AwsTile(AwsData):
         """
         self.tile_name = self.parse_tile_name(tile_name)
 
-        self.timestamp: dt.date = parse_time(time, ignoretz=True)  # type: ignore
+        self.timestamp: dt.date = parse_time(time, ignoretz=True)
         self.date = self.timestamp.date() if isinstance(self.timestamp, dt.datetime) else self.timestamp
 
         self.aws_index = aws_index

--- a/sentinelhub/data_collections.py
+++ b/sentinelhub/data_collections.py
@@ -107,7 +107,7 @@ def _shallow_asdict(dataclass_instance: Any) -> Dict[str, Any]:
 class _DataCollectionMeta(EnumMeta):
     """Metaclass that builds DataCollection class enums"""
 
-    def __call__(cls, value, *args, **kwargs):  # type: ignore
+    def __call__(cls, value, *args, **kwargs):  # type: ignore[no-untyped-def]
         """This is executed whenever `DataCollection('something')` is called
 
         This solves a problem of pickling a custom DataCollection and unpickling it in another process
@@ -147,7 +147,7 @@ class DataCollectionDefinition:
     # The following parameter is used to preserve custom DataCollection name during pickling and unpickling process:
     _name: Optional[str] = field(default=None, compare=False)
 
-    def __post_init__(self):  # type: ignore
+    def __post_init__(self):  # type: ignore[no-untyped-def] # not typechecked because we mutate immutable dataclasses
         """In case a list of bands or metabands has been given this makes sure to cast it into a tuple"""
         if isinstance(self.bands, list):
             object.__setattr__(self, "bands", tuple(self.bands))

--- a/sentinelhub/geo_utils.py
+++ b/sentinelhub/geo_utils.py
@@ -3,7 +3,7 @@ Module for manipulation of geographical information
 """
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, List, Optional, Sequence, Tuple, Union
+from typing import TYPE_CHECKING, List, Optional, Sequence, Tuple, Union, cast
 
 from .constants import CRS
 
@@ -193,5 +193,5 @@ def transform_point(
     """
     if source_crs == target_crs:
         return point
-    old_x, old_y = point
-    return CRS.get_transform_function(source_crs, target_crs, always_xy=always_xy)(old_x, old_y)  # type: ignore
+    transform_function = CRS.get_transform_function(source_crs, target_crs, always_xy=always_xy)
+    return cast(Tuple[float, float], transform_function(*point))

--- a/sentinelhub/geometry.py
+++ b/sentinelhub/geometry.py
@@ -379,7 +379,8 @@ class BBox(_BaseGeometry):
         :raises: TypeError
         """
         if len(bbox) == 4:
-            return tuple(map(float, bbox))  # type: ignore # iterator length
+            min_x, min_y, max_x, max_y = map(float, bbox)
+            return min_x, min_y, max_x, max_y
         if len(bbox) == 2 and all(isinstance(point, (list, tuple)) for point in bbox):
             return BBox._tuple_from_list_or_tuple(bbox[0] + bbox[1])
         raise TypeError("Expected a valid list or tuple representation of a bbox")
@@ -391,7 +392,11 @@ class BBox(_BaseGeometry):
         :param bbox: e.g. str of the form `min_x ,min_y  max_x, max_y`
         :return: tuple (min_x,min_y,max_x,max_y)
         """
-        return tuple(float(s) for s in bbox.replace(",", " ").split() if s)  # type: ignore # iterator length
+        string_parts = bbox.replace(",", " ").split()
+        if len(string_parts) != 4:
+            raise ValueError(f"Input {bbox} is not a valid string representation of a BBox.")
+        min_x, min_y, max_x, max_y = map(float, string_parts)
+        return min_x, min_y, max_x, max_y
 
     @staticmethod
     def _tuple_from_dict(bbox: dict) -> Tuple[float, float, float, float]:

--- a/sentinelhub/geopedia/core.py
+++ b/sentinelhub/geopedia/core.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import datetime
 import hashlib
-import sys
 from typing import TYPE_CHECKING, Any, Iterable, Iterator, List, Optional, Union, overload
 
 from shapely.geometry import shape as geo_shape
@@ -17,15 +16,10 @@ from ..config import SHConfig
 from ..constants import CRS, MimeType
 from ..download import DownloadClient, DownloadRequest
 from ..geometry import BBox
-from ..types import JsonDict
+from ..types import JsonDict, Literal
 
 if TYPE_CHECKING:
     from .request import GeopediaImageRequest
-
-if sys.version_info < (3, 8):
-    from typing_extensions import Literal
-else:
-    from typing import Literal  # pylint: disable=ungrouped-imports
 
 
 class GeopediaService:

--- a/sentinelhub/io_utils.py
+++ b/sentinelhub/io_utils.py
@@ -79,7 +79,7 @@ def _get_reader(data_format: MimeType) -> Callable[[str], Any]:
 def read_tar(filename: str) -> Dict[str, object]:
     """Read a tar from file"""
     with open(filename, "rb") as file:
-        return decode_tar(file)  # type: ignore
+        return decode_tar(file)  # type: ignore[arg-type]
 
 
 def read_tiff_image(filename: str) -> Any:

--- a/sentinelhub/os_utils.py
+++ b/sentinelhub/os_utils.py
@@ -1,18 +1,19 @@
 """
 Module for managing files and folders
 """
-
 import errno
+import functools
 import os
 import warnings
 from sys import platform
-from typing import Callable, List
+from typing import Any, Callable, List
 
 from .exceptions import SHDeprecationWarning
 
 
 def deprecated(func: Callable) -> Callable:  # pylint: disable=missing-docstring
-    def deprecated_func(*args, **kwargs):  # type: ignore
+    @functools.wraps(func)
+    def deprecated_func(*args: Any, **kwargs: Any) -> Any:
         warnings.warn(
             (
                 f"Function `{func.__name__}` is part of `sentinelhub.os_utils` module, which is deprecated and will be"

--- a/sentinelhub/testing_utils.py
+++ b/sentinelhub/testing_utils.py
@@ -2,7 +2,7 @@
 Utility tools for writing unit tests for packages which rely on `sentinelhub-py`
 """
 import os
-from typing import Optional, Tuple
+from typing import Any, Callable, Dict, Optional, Tuple
 from warnings import warn
 
 import numpy as np
@@ -68,7 +68,7 @@ def assert_statistics_match(
     :param abs_delta: Precision of validation (absolute)
     """
 
-    stats_suite = {
+    stats_suite: Dict[str, Tuple[Callable[[np.ndarray], Any], Any]] = {
         "shape": (lambda array: array.shape, exp_shape),
         "dtype": (lambda array: array.dtype, exp_dtype),
         "min": (np.nanmin, exp_min),
@@ -80,10 +80,11 @@ def assert_statistics_match(
 
     is_precise = {"shape", "dtype"}
 
-    data_stats, exp_stats = {}, {}
+    data_stats: Dict[str, Any] = {}
+    exp_stats: Dict[str, Any] = {}
     for name, (func, expected) in stats_suite.items():
         if expected is not None:
-            data_stats[name] = func(data)  # type: ignore # unknown function
+            data_stats[name] = func(data)
             exp_stats[name] = expected if name in is_precise else approx(expected, rel=rel_delta, abs=abs_delta)
 
     assert data_stats == exp_stats, "Statistics differ from expected values"

--- a/sentinelhub/time_utils.py
+++ b/sentinelhub/time_utils.py
@@ -7,7 +7,7 @@ from typing import Any, Iterable, List, Optional, Tuple, TypeVar, Union, overloa
 import dateutil.parser
 import dateutil.tz
 
-from .types import RawTimeIntervalType, RawTimeType
+from .types import Literal, RawTimeIntervalType, RawTimeType
 
 TimeType = TypeVar("TimeType", dt.date, dt.datetime)  # pylint: disable=invalid-name
 
@@ -23,6 +23,38 @@ def is_valid_time(time: str) -> bool:
         return True
     except dateutil.parser.ParserError:
         return False
+
+
+@overload
+def parse_time(
+    time_input: RawTimeType,
+    *,
+    force_datetime: Literal[False] = False,
+    allow_undefined: Literal[False] = False,
+    **kwargs: Any
+) -> dt.date:
+    ...
+
+
+@overload
+def parse_time(
+    time_input: RawTimeType, *, force_datetime: Literal[True], allow_undefined: Literal[False] = False, **kwargs: Any
+) -> dt.datetime:
+    ...
+
+
+@overload
+def parse_time(
+    time_input: RawTimeType, *, force_datetime: Literal[False] = False, allow_undefined: bool = False, **kwargs: Any
+) -> Optional[dt.date]:
+    ...
+
+
+@overload
+def parse_time(
+    time_input: RawTimeType, *, force_datetime: Literal[True], allow_undefined: bool = False, **kwargs: Any
+) -> Optional[dt.datetime]:
+    ...
 
 
 def parse_time(
@@ -87,9 +119,9 @@ def parse_time_interval(
         parsed_time = parse_time(time, **kwargs)
         date_interval = parsed_time, parsed_time
     elif isinstance(time, (tuple, list)) and len(time) == 2:
-        date_interval = parse_time(time[0], allow_undefined=allow_undefined, **kwargs), parse_time(
-            time[1], allow_undefined=allow_undefined, **kwargs
-        )
+        start_date = parse_time(time[0], allow_undefined=allow_undefined, **kwargs)
+        end_date = parse_time(time[1], allow_undefined=allow_undefined, **kwargs)
+        date_interval = start_date, end_date
     else:
         raise ValueError("Time must be a string/datetime object or tuple/list of 2 strings/datetime objects")
 

--- a/sentinelhub/types.py
+++ b/sentinelhub/types.py
@@ -1,8 +1,15 @@
 """Module with custom types and utilities used in sentinelhub-py."""
 import datetime as dt
+import sys
 from typing import Any, Dict, Tuple, Union
 
 RawTimeType = Union[None, str, dt.date]
 RawTimeIntervalType = Tuple[RawTimeType, RawTimeType]
 JsonDict = Dict[str, Any]
 Json = Union[JsonDict, list, str, float, int, None]
+
+
+if sys.version_info < (3, 8):
+    from typing_extensions import Literal  # pylint: disable=unused-import
+else:
+    from typing import Literal  # pylint: disable=ungrouped-imports  # noqa: F401


### PR DESCRIPTION
I tried to remove each `type: ignore` comment, if not possible i specialized it with the appropriate error code.

AWS and Geopedia modules were left out of this. 