### PR TITLE
Restrict valid `BBox` inputs

### DIFF
--- a/sentinelhub/api/batch/process.py
+++ b/sentinelhub/api/batch/process.py
@@ -542,7 +542,7 @@ class BatchRequest(BaseBatchRequest):  # pylint: disable=abstract-method
         bbox, _, crs = self._parse_bounds_payload()
         if bbox is None:
             raise ValueError("Bounding box is not defined for this batch request")
-        return BBox(bbox, crs)
+        return BBox(bbox, crs)  # type: ignore[arg-type]
 
     @property
     def geometry(self) -> Geometry:

--- a/sentinelhub/areas.py
+++ b/sentinelhub/areas.py
@@ -139,7 +139,7 @@ class AreaSplitter(metaclass=ABCMeta):
         area_min_y = min(bbox.lower_left[1] for bbox in bbox_list)
         area_max_x = max(bbox.upper_right[0] for bbox in bbox_list)
         area_max_y = max(bbox.upper_right[1] for bbox in bbox_list)
-        bbox = BBox([area_min_x, area_min_y, area_max_x, area_max_y], crs=self.crs)
+        bbox = BBox((area_min_x, area_min_y, area_max_x, area_max_y), crs=self.crs)
         if crs is None:
             return bbox
         return bbox.transform(crs)
@@ -688,12 +688,12 @@ class BatchSplitter(AreaSplitter):
         width, height = self.tile_size
 
         return BBox(
-            [
+            (
                 upper_left_corner[0] - self.tile_buffer[0],
                 upper_left_corner[1] - height - self.tile_buffer[1],
                 upper_left_corner[0] + width + self.tile_buffer[0],
                 upper_left_corner[1] + self.tile_buffer[1],
-            ],
+            ),
             tile_crs,
         )
 

--- a/sentinelhub/geometry.py
+++ b/sentinelhub/geometry.py
@@ -143,7 +143,10 @@ class BBox(_BaseGeometry):
                 stacklevel=2,
             )
             return bbox.bounds
-        raise TypeError("Invalid bbox representation")
+        raise TypeError(
+            "Unable to process `BBox` input. Provide `(min_x, min_y, max_x, max_y)` or check documentation for other"
+            " valid forms of input."
+        )
 
     @staticmethod
     def _tuple_from_list_or_tuple(

--- a/sentinelhub/geometry.py
+++ b/sentinelhub/geometry.py
@@ -401,12 +401,10 @@ class BBox(_BaseGeometry):
         return [
             [
                 BBox(
-                    [
-                        self.min_x + i * size_x,
-                        self.min_y + j * size_y,
-                        self.min_x + (i + 1) * size_x,
-                        self.min_y + (j + 1) * size_y,
-                    ],
+                    (
+                        (self.min_x + i * size_x, self.min_y + j * size_y),
+                        (self.min_x + (i + 1) * size_x, self.min_y + (j + 1) * size_y),
+                    ),
                     crs=self.crs,
                 )
                 for j in range(num_y)

--- a/sentinelhub/geometry.py
+++ b/sentinelhub/geometry.py
@@ -529,7 +529,7 @@ class Geometry(_BaseGeometry):
 
         :return: A bounding box, with same CRS
         """
-        return BBox(self.geometry, self.crs)
+        return BBox(self.geometry.bounds, self.crs)
 
     @staticmethod
     def _parse_geometry(geometry: Union[Polygon, MultiPolygon, dict, str]) -> Union[Polygon, MultiPolygon]:

--- a/tests/aws/test_data.py
+++ b/tests/aws/test_data.py
@@ -5,7 +5,7 @@ from pytest import approx
 from sentinelhub import DataCollection
 from sentinelhub.aws import AwsProductRequest, AwsTileRequest
 
-pytestmark = pytest.mark.filterwarnings("ignore::DeprecationWarning")
+pytestmark = [pytest.mark.aws_integration, pytest.mark.filterwarnings("ignore::DeprecationWarning")]
 
 
 def test_aws_tile(output_folder: str) -> None:

--- a/tests/aws/test_data.py
+++ b/tests/aws/test_data.py
@@ -5,7 +5,7 @@ from pytest import approx
 from sentinelhub import DataCollection
 from sentinelhub.aws import AwsProductRequest, AwsTileRequest
 
-pytestmark = pytest.mark.aws_integration
+pytestmark = pytest.mark.filterwarnings("ignore::DeprecationWarning")
 
 
 def test_aws_tile(output_folder: str) -> None:

--- a/tests/aws/test_data_safe.py
+++ b/tests/aws/test_data_safe.py
@@ -6,6 +6,8 @@ import pytest
 from sentinelhub import DataCollection, read_data
 from sentinelhub.aws import AwsConstants, AwsProductRequest, AwsTileRequest
 
+pytestmark = [pytest.mark.aws_integration, pytest.mark.filterwarnings("ignore::DeprecationWarning")]
+
 
 @pytest.fixture(name="safe_folder", scope="session")
 def safe_folder_fixture(input_folder: str) -> str:

--- a/tests/aws/test_request.py
+++ b/tests/aws/test_request.py
@@ -4,6 +4,8 @@ import pytest
 
 from sentinelhub.aws import AwsProductRequest
 
+pytestmark = pytest.mark.filterwarnings("ignore::DeprecationWarning")
+
 
 @pytest.mark.aws_integration
 def test_saving_responses(output_folder: str) -> None:

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -29,25 +29,7 @@ def _round_point_coords(x: float, y: float, decimals: int = 1) -> Tuple[float, f
 
 def test_bbox_no_crs() -> None:
     with pytest.raises(TypeError):
-        BBox("46,13,47,20")  # type: ignore[call-arg]
-
-
-def test_bbox_from_string() -> None:
-    bbox_str = "46.07, 13.23, 46.24, 13.57"
-    bbox = BBox(bbox_str, CRS.WGS84)
-    assert bbox.lower_left == (46.07, 13.23)
-    assert bbox.upper_right == (46.24, 13.57)
-    assert bbox.crs == CRS.WGS84
-
-
-def test_bbox_from_bad_string() -> None:
-    with pytest.raises(ValueError):
-        # Too few coordinates
-        BBox("46.07, 13.23, 46.24", CRS.WGS84)
-
-    with pytest.raises(ValueError):
-        # Invalid string
-        BBox("46N,13E,45N,12E", CRS.WGS84)
+        BBox((46, 13, 47, 20))  # type: ignore[call-arg]
 
 
 @pytest.mark.parametrize(
@@ -74,7 +56,6 @@ def test_bbox_from_flat_list(bbox_coords: List[float]) -> None:
         ((46.07, 13.23), (46.24, 13.57)),
         [(46.07, 13.23), (46.24, 13.57)],
         {"min_x": 46.07, "min_y": 13.23, "max_x": 46.24, "max_y": 13.57},
-        BBox({"min_x": 46.07, "min_y": 13.23, "max_x": 46.24, "max_y": 13.57}, CRS.WGS84),
     ],
 )
 def test_bbox_different_input(bbox_input: Any) -> None:
@@ -88,18 +69,6 @@ def test_bbox_from_bad_dict() -> None:
     bbox_dict = {"x1": 46.07, "y1": 13.23, "x2": 46.24, "y2": 13.57}
     with pytest.raises(KeyError):
         BBox(bbox_dict, CRS.WGS84)
-
-
-@pytest.mark.parametrize(
-    "bbox_input",
-    [
-        shapely.geometry.LineString([(0, 0), (1, 1)]),
-        shapely.geometry.LinearRing([(1, 0), (1, 1), (0, 0)]),
-        shapely.geometry.Polygon([(1, 0), (1, 1), (0, 0)]),
-    ],
-)
-def test_bbox_from_shapely(bbox_input: Any) -> None:
-    assert BBox(bbox_input, CRS.WGS84) == BBox((0, 0, 1, 1), CRS.WGS84)
 
 
 def test_bbox_to_str() -> None:
@@ -238,8 +207,8 @@ def test_wkt() -> None:
 
 
 @pytest.mark.parametrize("geometry", [GEOMETRY1, GEOMETRY2])
-def test_bbox(geometry: Geometry) -> None:
-    assert geometry.bbox == BBox(geometry.geometry, geometry.crs), "Failed bbox property"
+def test_bbox_of_geometry(geometry: Geometry) -> None:
+    assert geometry.bbox == BBox(geometry.geometry.bounds, geometry.crs), "Failed bbox property"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This will slim down the code required and improve safety due to better typing.
It additionally forces the users to properly look at their data before initializing the class. 

I also silenced AWS warnings so that it is easier to detect warnings when running the test suite.