### PR TITLE
Deprecate and avoid methods for certain urls

### DIFF
--- a/sentinelhub/api/ogc.py
+++ b/sentinelhub/api/ogc.py
@@ -271,7 +271,7 @@ class OgcImageService:
         self.config = config or SHConfig()
         self.config.raise_for_missing_instance_id()
 
-        self._base_url = self.config.get_sh_ogc_url()
+        self._base_url = f"{self.config.sh_base_url}/ogc"
         self.wfs_iterator: Optional[WebFeatureService] = None
 
     def get_request(self, request: OgcRequest) -> List[DownloadRequest]:

--- a/sentinelhub/api/wfs.py
+++ b/sentinelhub/api/wfs.py
@@ -69,7 +69,7 @@ class WebFeatureService(FeatureIterator[JsonDict]):
 
     def _build_service_url(self) -> str:
         """Creates a base URL for WFS service"""
-        base_url = self.config.get_sh_ogc_url()
+        base_url = f"{self.config.sh_base_url}/ogc"
 
         if self.data_collection.service_url:
             base_url = base_url.replace(self.config.sh_base_url, self.data_collection.service_url)

--- a/sentinelhub/config.py
+++ b/sentinelhub/config.py
@@ -9,6 +9,8 @@ import numbers
 import os
 from typing import Any, Dict, Iterable, List, Optional, Union
 
+from .exceptions import deprecated_function
+
 ConfigDict = Dict[str, Union[str, int, float]]
 
 
@@ -293,6 +295,7 @@ class SHConfig:  # pylint: disable=too-many-instance-attributes
         hide_size = min(max(len(value) - 4, 10), len(value))
         return "*" * hide_size + value[hide_size:]
 
+    @deprecated_function(message_suffix="Use `f'{config.sh_auth_base_url}/oauth/token'` instead.")
     def get_sh_oauth_url(self) -> str:
         """Provides URL for Sentinel Hub authentication endpoint
 
@@ -300,6 +303,7 @@ class SHConfig:  # pylint: disable=too-many-instance-attributes
         """
         return f"{self.sh_auth_base_url}/oauth/token"
 
+    @deprecated_function(message_suffix="Use `f'{config.sh_base_url}/api/v1/process'` instead.")
     def get_sh_process_api_url(self) -> str:
         """Provides URL for Sentinel Hub Process API endpoint
 
@@ -307,6 +311,7 @@ class SHConfig:  # pylint: disable=too-many-instance-attributes
         """
         return f"{self.sh_base_url}/api/v1/process"
 
+    @deprecated_function(message_suffix="Use `f'{config.sh_base_url}/ogc'` instead.")
     def get_sh_ogc_url(self) -> str:
         """Provides URL for Sentinel Hub OGC endpoint
 
@@ -314,6 +319,7 @@ class SHConfig:  # pylint: disable=too-many-instance-attributes
         """
         return f"{self.sh_base_url}/ogc"
 
+    @deprecated_function(message_suffix="Use `f'{config.sh_auth_base_url}/aux/ratelimit'` instead.")
     def get_sh_rate_limit_url(self) -> str:
         """Provides URL for Sentinel Hub rate limiting endpoint
 

--- a/sentinelhub/download/session.py
+++ b/sentinelhub/download/session.py
@@ -125,7 +125,7 @@ class SentinelHubSession:
         Note that the `DownloadRequest` object is created only because retry decorators of `_fetch_token` method
         require it.
         """
-        request = DownloadRequest(url=self.config.get_sh_oauth_url())
+        request = DownloadRequest(url=f"{self.config.sh_auth_base_url}/oauth/token")
         return self._fetch_token(request)
 
     @retry_temporary_errors


### PR DESCRIPTION
It makes no sense to have only a select few URLs on the config. So either we add the methods for all other URLS or we scrap the one-liners and inline them (like it's already done in Catalog API). 