### PR TITLE
Deprecate `BBox.__str__`

### DIFF
--- a/sentinelhub/api/ogc.py
+++ b/sentinelhub/api/ogc.py
@@ -388,8 +388,10 @@ class OgcImageService:
         :param date: acquisition date or None
         :return: dictionary with parameters
         """
+        bbox = request.bbox.reverse() if request.bbox.crs is CRS.WGS84 else request.bbox
+
         params = {
-            "BBOX": str(request.bbox.reverse()) if request.bbox.crs is CRS.WGS84 else str(request.bbox),
+            "BBOX": ",".join(map(str, bbox)),
             "FORMAT": MimeType.get_string(request.image_format),
             "CRS": CRS.ogc_string(request.bbox.crs),
         }

--- a/sentinelhub/api/opensearch.py
+++ b/sentinelhub/api/opensearch.py
@@ -186,6 +186,6 @@ def _prepare_url_params(
         "startDate": serialize_time(start_date, use_tz=False) if start_date else None,
         "completionDate": serialize_time(end_date, use_tz=False) if end_date else None,
         "orbitNumber": absolute_orbit,
-        "box": bbox,
+        "box": ",".join(map(str, bbox)) if bbox else None,
     }
     return {key: str(value) for key, value in url_params.items() if value}

--- a/sentinelhub/api/wfs.py
+++ b/sentinelhub/api/wfs.py
@@ -79,12 +79,13 @@ class WebFeatureService(FeatureIterator[JsonDict]):
     def _build_request_params(self) -> JsonDict:
         """Builds URL parameters for WFS service"""
         start_time, end_time = serialize_time(self.time_interval, use_tz=True)
+        bbox = self.bbox.reverse() if self.bbox.crs is CRS.WGS84 else self.bbox
         return {
             "SERVICE": ServiceType.WFS.value,
             "WARNINGS": False,
             "REQUEST": "GetFeature",
             "TYPENAMES": self.data_collection.wfs_id,
-            "BBOX": str(self.bbox.reverse()) if self.bbox.crs is CRS.WGS84 else str(self.bbox),
+            "BBOX": ",".join(map(str, bbox)),
             "OUTPUTFORMAT": MimeType.JSON.get_string(),
             "SRSNAME": self.bbox.crs.ogc_string(),
             "TIME": f"{start_time}/{end_time}",

--- a/sentinelhub/geometry.py
+++ b/sentinelhub/geometry.py
@@ -220,6 +220,11 @@ class BBox(_BaseGeometry):
         :param reverse: `True` if x and y coordinates should be switched and `False` otherwise
         :return: String of coordinates
         """
+        warnings.warn(
+            "The string representation of `BBox` will change to match its `repr` representation.",
+            category=SHDeprecationWarning,
+            stacklevel=2,
+        )
         if reverse:
             return f"{self.min_y},{self.min_x},{self.max_y},{self.max_x}"
         return f"{self.min_x},{self.min_y},{self.max_x},{self.max_y}"

--- a/sentinelhub/geopedia/core.py
+++ b/sentinelhub/geopedia/core.py
@@ -372,7 +372,7 @@ class GeopediaFeatureIterator(FeatureIterator[JsonDict]):
             if bbox.crs is not CRS.POP_WEB:
                 bbox = bbox.transform(CRS.POP_WEB)
 
-            params[self.FILTER_EXPRESSION] = f'bbox({bbox},"EPSG:3857")'
+            params[self.FILTER_EXPRESSION] = f'bbox({",".join(map(str, bbox))},"EPSG:3857")'
 
         if query_filter is not None:
             if self.FILTER_EXPRESSION in params:

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -1,4 +1,5 @@
 import copy
+import warnings
 from typing import Any, Tuple, TypeVar
 
 import pytest
@@ -6,6 +7,7 @@ import shapely.geometry
 from pytest import approx
 
 from sentinelhub import CRS, BBox, Geometry, get_utm_crs
+from sentinelhub.exceptions import SHDeprecationWarning
 
 GeoType = TypeVar("GeoType", BBox, Geometry)
 
@@ -51,8 +53,10 @@ def test_bbox_bad_input_options(coords: Any, crs: CRS) -> None:
 
 
 def test_bbox_to_str() -> None:
-    bbox = BBox(((45.0, 12.0, 47.0, 14.0)), CRS.WGS84)
-    assert str(bbox) == "45.0,12.0,47.0,14.0"
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", SHDeprecationWarning)
+        bbox = BBox(((45.0, 12.0, 47.0, 14.0)), CRS.WGS84)
+        assert str(bbox) == "45.0,12.0,47.0,14.0"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
It is clear that `"0,0,10,5"` is in no way an accurate representation of `BBox((0, 0), (10, 5), CRS(1234))` since it has no notion of the CRS.

The code makes it clear it was used as a crutch to 'jsonify' the bbox, but that is not the way to go. The old methods were adjusted to jsonify the BBox directly. 

A warning was added that the output will be changed in the future.