### PR TITLE
Move OGC and FIS enums to the api files

### DIFF
--- a/sentinelhub/__init__.py
+++ b/sentinelhub/__init__.py
@@ -30,6 +30,8 @@ from .api import (
     monitor_batch_statistical_job,
     opensearch,
 )
+from .api.fis import HistogramType
+from .api.ogc import CustomUrlParam
 from .api.opensearch import get_area_dates, get_area_info, get_tile_info, get_tile_info_id
 from .areas import (
     BatchSplitter,
@@ -41,17 +43,7 @@ from .areas import (
     UtmZoneSplitter,
 )
 from .config import SHConfig
-from .constants import (
-    CRS,
-    CustomUrlParam,
-    HistogramType,
-    MimeType,
-    MosaickingOrder,
-    ResamplingType,
-    ServiceType,
-    ServiceUrl,
-    SHConstants,
-)
+from .constants import CRS, MimeType, MosaickingOrder, ResamplingType, ServiceType, ServiceUrl, SHConstants
 from .data_collections import DataCollection
 from .data_collections_bands import Band, Unit
 from .download import (

--- a/sentinelhub/api/fis.py
+++ b/sentinelhub/api/fis.py
@@ -3,15 +3,27 @@ Module for working with Sentinel Hub FIS service
 """
 import datetime
 import warnings
+from enum import Enum
 from typing import Any, List, Optional, Union
 
-from ..constants import HistogramType, MimeType, RequestType, ServiceType
+from ..constants import MimeType, RequestType, ServiceType
 from ..download import DownloadRequest
 from ..exceptions import SHDeprecationWarning
 from ..geometry import BBox, Geometry
 from ..time_utils import RawTimeIntervalType, RawTimeType
 from .ogc import OgcImageService, OgcRequest
 from .wfs import WebFeatureService
+
+
+class HistogramType(Enum):
+    """Enum class for types of histogram supported by Sentinel Hub FIS service
+
+    Supported histogram types are EQUALFREQUENCY, EQUIDISTANT and STREAMING
+    """
+
+    EQUALFREQUENCY = "equalfrequency"
+    EQUIDISTANT = "equidistant"
+    STREAMING = "streaming"
 
 
 class FisRequest(OgcRequest):

--- a/sentinelhub/api/ogc.py
+++ b/sentinelhub/api/ogc.py
@@ -2,16 +2,16 @@
 Module for working with Sentinel Hub OGC services
 `Sentinel Hub OGC services <https://www.sentinel-hub.com/develop/api/ogc/standard-parameters/>`__.
 """
-
 import datetime
 import logging
 from base64 import b64encode
+from enum import Enum
 from typing import Any, Dict, List, Optional, Tuple, Union
 from urllib.parse import urlencode
 
 from ..base import DataRequest
 from ..config import SHConfig
-from ..constants import CRS, CustomUrlParam, MimeType, ResamplingType, ServiceType
+from ..constants import CRS, MimeType, ResamplingType, ServiceType
 from ..data_collections import DataCollection
 from ..download import DownloadRequest, SentinelHubDownloadClient
 from ..geo_utils import get_image_dimension
@@ -20,6 +20,44 @@ from ..time_utils import RawTimeIntervalType, RawTimeType, filter_times, parse_t
 from .wfs import WebFeatureService
 
 LOGGER = logging.getLogger(__name__)
+
+
+class CustomUrlParam(Enum):
+    """Enum class to represent supported custom url parameters of OGC services
+
+    Supported parameters are `SHOWLOGO`, `EVALSCRIPT`, `EVALSCRIPTURL`, `PREVIEW`, `QUALITY`, `UPSAMPLING`,
+    `DOWNSAMPLING`, `GEOMETRY` and `WARNINGS`.
+
+    See `documentation <https://www.sentinel-hub.com/develop/api/ogc/custom-parameters/>`__ for more information.
+    """
+
+    SHOWLOGO = "ShowLogo"
+    EVALSCRIPT = "EvalScript"
+    EVALSCRIPTURL = "EvalScriptUrl"
+    PREVIEW = "Preview"
+    QUALITY = "Quality"
+    UPSAMPLING = "Upsampling"
+    DOWNSAMPLING = "Downsampling"
+    GEOMETRY = "Geometry"
+    MINQA = "MinQA"
+
+    @classmethod
+    def has_value(cls, value: str) -> bool:
+        """Tests whether CustomUrlParam contains a constant defined with a string `value`
+
+        :param value: The string representation of the enum constant
+        :return: `True` if there exists a constant with a string value `value`, `False` otherwise
+        """
+        return any(value.lower() == item.value.lower() for item in cls)
+
+    @staticmethod
+    def get_string(param: Enum) -> str:
+        """Get custom url parameter name as string
+
+        :param param: CustomUrlParam enum constant
+        :return: String describing the file format
+        """
+        return param.value
 
 
 class OgcRequest(DataRequest):

--- a/sentinelhub/constants.py
+++ b/sentinelhub/constants.py
@@ -271,55 +271,6 @@ class CRS(Enum, metaclass=CRSMeta):
         return "+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs" if self is CRS.WGS84 else self.ogc_string()
 
 
-class CustomUrlParam(Enum):
-    """Enum class to represent supported custom url parameters of OGC services
-
-    Supported parameters are `SHOWLOGO`, `EVALSCRIPT`, `EVALSCRIPTURL`, `PREVIEW`, `QUALITY`, `UPSAMPLING`,
-    `DOWNSAMPLING`, `GEOMETRY` and `WARNINGS`.
-
-    See `documentation <https://www.sentinel-hub.com/develop/api/ogc/custom-parameters/>`__ for more information.
-    """
-
-    SHOWLOGO = "ShowLogo"
-    EVALSCRIPT = "EvalScript"
-    EVALSCRIPTURL = "EvalScriptUrl"
-    PREVIEW = "Preview"
-    QUALITY = "Quality"
-    UPSAMPLING = "Upsampling"
-    DOWNSAMPLING = "Downsampling"
-    GEOMETRY = "Geometry"
-    MINQA = "MinQA"
-
-    @classmethod
-    def has_value(cls, value: str) -> bool:
-        """Tests whether CustomUrlParam contains a constant defined with a string `value`
-
-        :param value: The string representation of the enum constant
-        :return: `True` if there exists a constant with a string value `value`, `False` otherwise
-        """
-        return any(value.lower() == item.value.lower() for item in cls)
-
-    @staticmethod
-    def get_string(param: Enum) -> str:
-        """Get custom url parameter name as string
-
-        :param param: CustomUrlParam enum constant
-        :return: String describing the file format
-        """
-        return param.value
-
-
-class HistogramType(Enum):
-    """Enum class for types of histogram supported by Sentinel Hub FIS service
-
-    Supported histogram types are EQUALFREQUENCY, EQUIDISTANT and STREAMING
-    """
-
-    EQUALFREQUENCY = "equalfrequency"
-    EQUIDISTANT = "equidistant"
-    STREAMING = "streaming"
-
-
 class MimeType(Enum):
     """Enum class to represent supported file formats
 


### PR DESCRIPTION
Since both OGC and FIS are not actively maintained it makes no sense to keep the API-specific files in the `constants.py` module.

This shouldn't break much code because they are imported in the top `__init__`. Also the services are deprecated, so we dont need to be that careful there.