### PR TITLE
Fix splitter issue when batch geometry is missing

### DIFF
--- a/sentinelhub/api/batch/process.py
+++ b/sentinelhub/api/batch/process.py
@@ -533,28 +533,24 @@ class BatchRequest(BaseBatchRequest):  # pylint: disable=abstract-method
         return self.process_request["evalscript"]
 
     @property
-    def bbox(self) -> BBox:
+    def bbox(self) -> Optional[BBox]:
         """Provides a bounding box used by a batch request
 
         :return: An area bounding box together with CRS
         :raises: ValueError
         """
         bbox, _, crs = self._parse_bounds_payload()
-        if bbox is None:
-            raise ValueError("Bounding box is not defined for this batch request")
-        return BBox(bbox, crs)  # type: ignore[arg-type]
+        return None if bbox is None else BBox(bbox, crs)  # type: ignore[arg-type]
 
     @property
-    def geometry(self) -> Geometry:
+    def geometry(self) -> Optional[Geometry]:
         """Provides a geometry used by a batch request
 
         :return: An area geometry together with CRS
         :raises: ValueError
         """
         _, geometry, crs = self._parse_bounds_payload()
-        if geometry is None:
-            raise ValueError("Geometry is not defined for this batch request")
-        return Geometry(geometry, crs)
+        return None if geometry is None else Geometry(geometry, crs)
 
     def _parse_bounds_payload(self) -> Tuple[Optional[List[float]], Optional[list], CRS]:
         """Parses bbox, geometry and crs from batch request payload. If bbox or geometry don't exist it returns None

--- a/sentinelhub/areas.py
+++ b/sentinelhub/areas.py
@@ -653,8 +653,9 @@ class BatchSplitter(AreaSplitter):
         self.tile_size = self._get_tile_size()
         self.tile_buffer = self._get_tile_buffer()
 
-        _, geom_def, _ = batch_request._parse_bounds_payload()
-        batch_geometry: _BaseGeometry = batch_request.geometry if geom_def else batch_request.bbox
+        batch_geometry: Optional[_BaseGeometry] = batch_request.geometry or batch_request.bbox
+        if batch_geometry is None:
+            raise ValueError("Batch request has both `bbox` and `geometry` set to `None`, which is invalid.")
 
         super().__init__([batch_geometry.geometry], batch_geometry.crs)
 

--- a/sentinelhub/areas.py
+++ b/sentinelhub/areas.py
@@ -653,7 +653,9 @@ class BatchSplitter(AreaSplitter):
         self.tile_size = self._get_tile_size()
         self.tile_buffer = self._get_tile_buffer()
 
-        batch_geometry = batch_request.geometry
+        _, geom_def, _ = batch_request._parse_bounds_payload()
+        batch_geometry: _BaseGeometry = batch_request.geometry if geom_def else batch_request.bbox
+
         super().__init__([batch_geometry.geometry], batch_geometry.crs)
 
     def _get_tile_size(self) -> Tuple[float, float]:


### PR DESCRIPTION
This is one of those "Its so easy, and yet so hard." problems.

The idea is really simple, if there is no `geometry`, just take the geometry of the `bbox`. But since both getters are throwing errors upon non-definition, we only have a private method that lets us check. But that again does not seem right, since it's a private method...

I am open to suggestions.

Closes #337 