### PR TITLE
Experimental new config setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,22 +1,21 @@
 # Makefile for creating a new release of the package and uploading it to PyPI
-# This way is preferred to manual because it also resets config.json
 
 PYTHON = python3
 CONFIG = sentinelhub.config
 
 help:
-	@echo "Use 'make upload' to reset config.json and upload the package to PyPi"
+	@echo "Use 'make upload' to upload the package to PyPi"
 
 reset-config:
 	$(CONFIG) --reset
 
-upload: reset-config
+upload:
 	rm -r dist | true
 	$(PYTHON) setup.py sdist
 	twine upload --skip-existing dist/*
 
 # For testing:
-test-upload: reset-config
+test-upload:
 	rm -r dist | true
 	$(PYTHON) setup.py sdist
 	twine upload --repository testpypi --skip-existing dist/*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,6 @@ source = [
 
 [tool.coverage.report]
 omit = [
-    "config.json",
     ".utmzones.geojson"
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ dataclasses-json
 numpy
 oauthlib
 pillow>=9.2.0
+platformdirs
 pyproj>=2.2.0
 python-dateutil
 requests>=2.27.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ dataclasses-json
 numpy
 oauthlib
 pillow>=9.2.0
-platformdirs
 pyproj>=2.2.0
 python-dateutil
 requests>=2.27.0

--- a/sentinelhub/commands.py
+++ b/sentinelhub/commands.py
@@ -48,7 +48,7 @@ def config(show: bool, reset: bool, **params: Any) -> None:
       sentinelhub.config --instance_id <new instance id>
       sentinelhub.config --max_download_attempts 5 --download_sleep_time 20 --download_timeout_seconds 120
     """
-    sh_config = SHConfig()
+    sh_config = SHConfig(hide_credentials=False)
 
     if reset:
         sh_config.reset()

--- a/sentinelhub/config.py
+++ b/sentinelhub/config.py
@@ -16,7 +16,7 @@ import platformdirs
 class SHConfig:  # pylint: disable=too-many-instance-attributes
     """A sentinelhub-py package configuration class.
 
-    The class reads during its first initialization the configurable settings from ``./config.json`` file:
+    The class reads the configurable settings from ``config.json`` file on initialization:
 
         - `instance_id`: An instance ID for Sentinel Hub service used for OGC requests.
         - `sh_client_id`: User's OAuth client ID for Sentinel Hub service
@@ -42,6 +42,9 @@ class SHConfig:  # pylint: disable=too-many-instance-attributes
           attempt this number exponentially increases with factor `3`.
         - `download_timeout_seconds`: Maximum number of seconds before download attempt is canceled.
         - `number_of_download_processes`: Number of download processes, used to calculate rate-limit sleep time.
+
+    For manual modification of `config.json` you can see the expected location of the file via
+    `SHConfig.get_config_location()`.
 
     Usage in the code:
 

--- a/sentinelhub/config.py
+++ b/sentinelhub/config.py
@@ -9,6 +9,8 @@ import numbers
 import os
 from typing import Any, Dict, Iterable, List, Optional, Union
 
+import platformdirs
+
 ConfigDict = Dict[str, Union[str, int, float]]
 
 
@@ -274,7 +276,8 @@ class SHConfig:  # pylint: disable=too-many-instance-attributes
 
         :return: File path of `config.json` file
         """
-        config_file = os.path.join(os.path.dirname(__file__), "config.json")
+        config_folder = platformdirs.user_config_dir("sentinelhub")
+        config_file = os.path.join(config_folder, "config.json")
 
         if not os.path.isfile(config_file):
             with open(config_file, "w") as cfg_file:

--- a/sentinelhub/config.py
+++ b/sentinelhub/config.py
@@ -10,8 +10,6 @@ import os
 from pathlib import Path
 from typing import Dict, Iterable, List, Optional, Union
 
-import platformdirs
-
 
 class SHConfig:  # pylint: disable=too-many-instance-attributes
     """A sentinelhub-py package configuration class.
@@ -255,8 +253,8 @@ class SHConfig:  # pylint: disable=too-many-instance-attributes
     @classmethod
     def get_config_location(cls) -> str:
         """Returns the default location of the user configuration file on disk."""
-        config_folder = platformdirs.user_config_dir("sentinelhub")
-        return os.path.join(config_folder, "config.json")
+        user_folder = os.path.expanduser("~")
+        return os.path.join(user_folder, ".config", "sentinelhub", "config.json")
 
     def _mask_credentials(self, param: str, value: object) -> object:
         """In case a parameter that holds credentials is given it will mask its value"""

--- a/sentinelhub/config.py
+++ b/sentinelhub/config.py
@@ -7,7 +7,7 @@ import copy
 import json
 import numbers
 import os
-from typing import Any, Dict, Iterable, List, Optional, Union
+from typing import Dict, Iterable, List, Optional, Union
 
 import platformdirs
 
@@ -82,13 +82,10 @@ class SHConfig:  # pylint: disable=too-many-instance-attributes
         "number_of_download_processes",
     ]
 
-    _cache: Optional[Dict[str, Any]] = None
-
-    def __init__(self, hide_credentials: bool = False, use_defaults: bool = False):
+    def __init__(self, hide_credentials: bool = True, use_defaults: bool = False):
         """
         :param hide_credentials: If `True` then methods that provide the entire content of the config object will mask
-            out all credentials. But credentials could still be accessed directly from config object attributes. The
-            default is `False`.
+            out all credentials. But credentials could still be accessed directly from config object attributes.
         :param use_defaults: Does not load the configuration file, returns config object with defaults only.
         """
 

--- a/sentinelhub/config.py
+++ b/sentinelhub/config.py
@@ -11,8 +11,6 @@ from typing import Dict, Iterable, List, Optional, Union
 
 import platformdirs
 
-ConfigDict = Dict[str, Union[str, int, float]]
-
 
 class SHConfig:  # pylint: disable=too-many-instance-attributes
     """A sentinelhub-py package configuration class.
@@ -240,7 +238,7 @@ class SHConfig:  # pylint: disable=too-many-instance-attributes
         """
         return list(self.CONFIG_PARAMS)
 
-    def get_config_dict(self) -> ConfigDict:
+    def get_config_dict(self) -> Dict[str, Union[str, float]]:
         """Get a dictionary representation of `SHConfig` class. If `hide_credentials` is set to `True` then
         credentials will be masked.
 

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,6 @@ setup(
     packages=find_packages(),
     package_data={
         "sentinelhub": [
-            "sentinelhub/config.json",
             "sentinelhub/.utmzones.geojson",
             "sentinelhub/py.typed",
         ]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -81,13 +81,11 @@ def test_config_file() -> None:
 def test_set_and_reset_value() -> None:
     config = SHConfig()
 
-    old_value = config.instance_id
     new_value = "new"
 
     config.instance_id = new_value
     assert config.instance_id == new_value, "New value was not set"
     assert config["instance_id"] == new_value, "New value was not set"
-    assert config._cache["instance_id"] == old_value, "Private value has changed"
 
     config.reset("sh_base_url")
     config.reset(["aws_access_key_id", "aws_secret_access_key"])

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -31,7 +31,6 @@ def mask_and_restore_config_fixture() -> Generator[None, None, None]:
 
     os.remove(config_path)
     shutil.move(cache_path, config_path)
-    SHConfig._cache = None  # makes sure the next invocation loads the SHConfig
 
 
 @pytest.fixture(name="restore_config_file")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -124,7 +124,6 @@ def test_copy(hide_credentials: bool) -> None:
     copied_config = config.copy()
     assert copied_config is not config
     assert copied_config._hide_credentials == hide_credentials
-    assert copied_config._cache is config._cache
     assert copied_config.instance_id == config.instance_id
 
     copied_config.instance_id = "b"


### PR DESCRIPTION
Changes:
- No more global cache!
- Config is moved to a standardized user appdata location (`~/.config/sentinelhub/config.json` for Linux users)
- Credentials are masked by default, applies only to `str` and `repr` (not sure why that was not the case...)
- lots of refactoring

a separate MR shall introduce user profiles to remedy the loss of 'managing-different-credentials-through-python-envs'