### PR TITLE
remove workaround for requests with no  dataFilter

### DIFF
--- a/sentinelhub/api/batch/statistical.py
+++ b/sentinelhub/api/batch/statistical.py
@@ -65,15 +65,8 @@ class SentinelHubBatchStatistical(BaseBatchClient["BatchStatisticalRequest"]):
         `Batch Statistical API reference
         <https://docs.sentinel-hub.com/api/latest/reference/#operation/createNewBatchStatisticsRequest>`__
         """
-
-        # Data filter has to be set to {} if not provided. Ensure we do not mutate original data.
-        requested_data = list(input_data)
-        for i, data_request_dict in enumerate(requested_data):
-            if "dataFilter" not in data_request_dict:
-                requested_data[i] = {"dataFilter": {}, **data_request_dict}
-
         payload = {
-            "input": {"features": input_features, "data": requested_data},
+            "input": {"features": input_features, "data": list(input_data)},
             "aggregation": aggregation,
             "calculations": calculations,
             "output": output,

--- a/sentinelhub/api/statistical.py
+++ b/sentinelhub/api/statistical.py
@@ -75,13 +75,8 @@ class SentinelHubStatistical(SentinelHubBaseApiRequest):
             by it.
         :returns: Request payload dictionary
         """
-        requested_data = list(request_data)
-        for i, data_request_dict in enumerate(requested_data):
-            if "dataFilter" not in data_request_dict:
-                requested_data[i] = {"dataFilter": {}, **data_request_dict}
-
         request_body = {
-            "input": {"bounds": request_bounds, "data": requested_data},
+            "input": {"bounds": request_bounds, "data": list(request_data)},
             "aggregation": aggregation,
             "calculations": calculations,
         }


### PR DESCRIPTION
Before SH 4.172.0 the `dataFilter` field was mandatory, but now it is no longer. We can thus simplify both statistical APIs