### PR TITLE
Further changes to SHConfig

### DIFF
--- a/sentinelhub/commands.py
+++ b/sentinelhub/commands.py
@@ -2,6 +2,7 @@
 Module that implements command line interface for the package
 """
 
+import json
 from typing import Any, Callable, TypeVar
 
 import click
@@ -48,7 +49,7 @@ def config(show: bool, reset: bool, **params: Any) -> None:
       sentinelhub.config --instance_id <new instance id>
       sentinelhub.config --max_download_attempts 5 --download_sleep_time 20 --download_timeout_seconds 120
     """
-    sh_config = SHConfig(hide_credentials=False)
+    sh_config = SHConfig()
 
     if reset:
         sh_config.reset()
@@ -76,7 +77,8 @@ def config(show: bool, reset: bool, **params: Any) -> None:
             click.echo(f"The value of parameter `{param}` was updated to {value}")
 
     if show:
-        click.echo(str(sh_config))
+        unmasked_str_repr = json.dumps(sh_config.to_dict(mask_credentials=False), indent=2)
+        click.echo(unmasked_str_repr)
         click.echo(f"Configuration file location: {sh_config.get_config_location()}")
 
 

--- a/sentinelhub/commands.py
+++ b/sentinelhub/commands.py
@@ -69,8 +69,8 @@ def config(show: bool, reset: bool, **params: Any) -> None:
     sh_config.save()
 
     for param in sh_config.get_params():
-        if getattr(sh_config, param) != getattr(old_config, param):
-            value = getattr(sh_config, param)
+        value = getattr(sh_config, param)
+        if value != getattr(old_config, param):
             if isinstance(value, str):
                 value = f"'{value}'"
             click.echo(f"The value of parameter `{param}` was updated to {value}")

--- a/sentinelhub/commands.py
+++ b/sentinelhub/commands.py
@@ -69,8 +69,8 @@ def config(show: bool, reset: bool, **params: Any) -> None:
     sh_config.save()
 
     for param in sh_config.get_params():
-        if sh_config[param] != old_config[param]:
-            value = sh_config[param]
+        if getattr(sh_config, param) != getattr(old_config, param):
+            value = getattr(sh_config, param)
             if isinstance(value, str):
                 value = f"'{value}'"
             click.echo(f"The value of parameter `{param}` was updated to {value}")

--- a/sentinelhub/config.py
+++ b/sentinelhub/config.py
@@ -131,12 +131,6 @@ class SHConfig:  # pylint: disable=too-many-instance-attributes
         if self.max_opensearch_records_per_query > 500:
             raise ValueError("Value of config parameter `max_opensearch_records_per_query` must be at most 500")
 
-    def __getitem__(self, name: str) -> Union[str, float]:
-        """Config parameters can also be accessed as items."""
-        if name in self.CONFIG_PARAMS:
-            return getattr(self, name)
-        raise KeyError(f"`{name}` is not a supported config parameter")
-
     def __str__(self) -> str:
         """Content of SHConfig in json schema. If `hide_credentials` is set to `True` then credentials are masked."""
         return json.dumps(self.get_config_dict(), indent=2)

--- a/sentinelhub/config.py
+++ b/sentinelhub/config.py
@@ -10,8 +10,6 @@ import os
 from pathlib import Path
 from typing import Dict, Iterable, Optional, Tuple, Union
 
-from .exceptions import deprecated_function
-
 
 class SHConfig:  # pylint: disable=too-many-instance-attributes
     """A sentinelhub-py package configuration class.
@@ -220,15 +218,6 @@ class SHConfig:  # pylint: disable=too-many-instance-attributes
     def get_params(cls) -> Tuple[str, ...]:
         """Returns a list of parameter names."""
         return cls.CREDENTIALS + cls.OTHER_PARAMS
-
-    @deprecated_function(message_suffix="Use `to_dict` instead.")
-    def get_config_dict(self) -> Dict[str, Union[str, float]]:
-        """Get a dictionary representation of `SHConfig` class. If `hide_credentials` is set to `True` then
-        credentials will be masked.
-
-        :return: A dictionary with configuration parameters
-        """
-        return self.to_dict()
 
     def to_dict(self, mask_credentials: bool = True) -> Dict[str, Union[str, float]]:
         """Get a dictionary representation of `SHConfig` class.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -53,7 +53,7 @@ def test_config_fixture() -> SHConfig:
 @pytest.mark.dependency()
 def test_fake_config_during_tests() -> None:
     config = SHConfig()
-    credentials_removed = all(config[field] == "" for field in config.CREDENTIALS)
+    credentials_removed = all(getattr(config, field) == "" for field in config.CREDENTIALS)
     assert credentials_removed, "Credentials not properly removed for testing. Aborting tests."
 
 
@@ -73,7 +73,7 @@ def test_config_file() -> None:
         if isinstance(value, str):
             value = value.rstrip("/")
 
-        assert config[param] == value, f"Parameter {param} does not match it's equivalent in the config.json."
+        assert getattr(config, param) == value, f"Parameter {param} does not match it's equivalent in the config.json."
 
 
 @pytest.mark.dependency(depends=["test_fake_config_during_tests"])
@@ -84,7 +84,6 @@ def test_set_and_reset_value() -> None:
 
     config.instance_id = new_value
     assert config.instance_id == new_value, "New value was not set"
-    assert config["instance_id"] == new_value, "New value was not set"
 
     config.reset("sh_base_url")
     config.reset(["aws_access_key_id", "aws_secret_access_key"])
@@ -167,7 +166,7 @@ def test_config_repr(hide_credentials: bool) -> None:
         assert "*" * 16 + "a" * 4 in config_repr
     else:
         for param in config.get_params():
-            assert f"{param}={repr(config[param])}" in config_repr
+            assert f"{param}={repr(getattr(config, param))}" in config_repr
 
 
 @pytest.mark.dependency(depends=["test_fake_config_during_tests"])

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -131,7 +131,7 @@ def test_copy(hide_credentials: bool) -> None:
 @pytest.mark.dependency(depends=["test_fake_config_during_tests"])
 def test_config_equality(test_config: SHConfig) -> None:
     assert test_config != 42
-    assert test_config != test_config.get_config_dict()
+    assert test_config != test_config.to_dict()
 
     config1 = SHConfig(hide_credentials=False)
     config2 = SHConfig(hide_credentials=True)
@@ -171,12 +171,12 @@ def test_config_repr(hide_credentials: bool) -> None:
 
 @pytest.mark.dependency(depends=["test_fake_config_during_tests"])
 @pytest.mark.parametrize("hide_credentials", [False, True])
-def test_get_config_dict(hide_credentials: bool) -> None:
+def test_transformation_to_dict(hide_credentials: bool) -> None:
     config = SHConfig(hide_credentials=hide_credentials)
     config.sh_client_secret = "x" * 15
     config.aws_secret_access_key = "y" * 10
 
-    config_dict = config.get_config_dict()
+    config_dict = config.to_dict(hide_credentials)
     assert isinstance(config_dict, dict)
     assert tuple(config_dict) == config.get_params()
 
@@ -197,7 +197,7 @@ def test_transfer_with_ray(test_config: SHConfig, ray: Any) -> None:
     def _remote_ray_testing(remote_config: SHConfig) -> SHConfig:
         """Makes a few checks and modifications to the config object"""
         assert repr(remote_config).startswith("SHConfig")
-        assert isinstance(remote_config.get_config_dict(), dict)
+        assert isinstance(remote_config.to_dict(), dict)
         assert os.path.exists(remote_config.get_config_location())
         assert remote_config.instance_id == "fake_instance_id"
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -114,14 +114,12 @@ def test_save(restore_config_file: None) -> None:
 
 
 @pytest.mark.dependency(depends=["test_fake_config_during_tests"])
-@pytest.mark.parametrize("hide_credentials", [True, False])
-def test_copy(hide_credentials: bool) -> None:
-    config = SHConfig(hide_credentials=hide_credentials)
+def test_copy() -> None:
+    config = SHConfig()
     config.instance_id = "a"
 
     copied_config = config.copy()
     assert copied_config is not config
-    assert copied_config._hide_credentials == hide_credentials
     assert copied_config.instance_id == config.instance_id
 
     copied_config.instance_id = "b"
@@ -133,8 +131,8 @@ def test_config_equality(test_config: SHConfig) -> None:
     assert test_config != 42
     assert test_config != test_config.to_dict()
 
-    config1 = SHConfig(hide_credentials=False)
-    config2 = SHConfig(hide_credentials=True)
+    config1 = SHConfig()
+    config2 = SHConfig()
 
     assert config1 is not config2
     assert config1 == config2
@@ -153,26 +151,24 @@ def test_raise_for_missing_instance_id(test_config: SHConfig) -> None:
 
 
 @pytest.mark.dependency(depends=["test_fake_config_during_tests"])
-@pytest.mark.parametrize("hide_credentials", [False, True])
-def test_config_repr(hide_credentials: bool) -> None:
-    config = SHConfig(hide_credentials=hide_credentials)
+def test_config_repr() -> None:
+    config = SHConfig()
     config.instance_id = "a" * 20
     config_repr = repr(config)
 
     assert config_repr.startswith(SHConfig.__name__)
 
-    if hide_credentials:
-        assert config.instance_id not in config_repr
-        assert "*" * 16 + "a" * 4 in config_repr
-    else:
-        for param in config.get_params():
-            assert f"{param}={repr(getattr(config, param))}" in config_repr
+    assert config.instance_id not in config_repr, "Credentials are not masked properly."
+    assert "*" * 16 + "a" * 4 in config_repr, "Credentials are not masked properly."
+
+    for param in SHConfig.OTHER_PARAMS:
+        assert f"{param}={repr(getattr(config, param))}" in config_repr
 
 
 @pytest.mark.dependency(depends=["test_fake_config_during_tests"])
 @pytest.mark.parametrize("hide_credentials", [False, True])
 def test_transformation_to_dict(hide_credentials: bool) -> None:
-    config = SHConfig(hide_credentials=hide_credentials)
+    config = SHConfig()
     config.sh_client_secret = "x" * 15
     config.aws_secret_access_key = "y" * 10
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -179,7 +179,7 @@ def test_get_config_dict(hide_credentials: bool) -> None:
 
     config_dict = config.get_config_dict()
     assert isinstance(config_dict, dict)
-    assert list(config_dict) == config.get_params()
+    assert tuple(config_dict) == config.get_params()
 
     if hide_credentials:
         assert config_dict["sh_client_secret"] == "*" * 11 + "x" * 4


### PR DESCRIPTION
- removes dictionary-style access
- renames `get_config_dictionary` to the shorter and more common `to_dict` (am willing to accept new names as well). `hide_credentials` is now a parameter, the on at `__init__` only controls masking in `repr` and `str`
- class attributes specifying which attributes are regular fields and which are credentials have been changed to tuples. The `get_params` accessor is used instead of direct access, allowing us to remove duplication.