### PR TITLE
Let `SHConfig` use environment

### DIFF
--- a/sentinelhub/config.py
+++ b/sentinelhub/config.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import copy
 import json
-import logging
 import numbers
 import os
 from pathlib import Path
@@ -13,8 +12,6 @@ from typing import Dict, Iterable, Optional, Tuple, Union
 
 import tomli
 import tomli_w
-
-LOGGER = logging.getLogger(__name__)
 
 DEFAULT_PROFILE = "default-profile"
 SH_PROFILE_ENV_VAR = "SH_PROFILE"
@@ -117,7 +114,7 @@ class SHConfig:  # pylint: disable=too-many-instance-attributes
         self.download_timeout_seconds: float = 120.0
         self.number_of_download_processes: int = 1
 
-        profile = self._override_with_env_var(SH_PROFILE_ENV_VAR, profile)
+        profile = os.environ.get(SH_PROFILE_ENV_VAR, default=profile)
 
         if not use_defaults:
             # load from config.toml
@@ -126,17 +123,8 @@ class SHConfig:  # pylint: disable=too-many-instance-attributes
                 setattr(self, param, getattr(loaded_instance, param))
 
             # check env
-            self.sh_client_id = self._override_with_env_var(SH_CLIENT_ID_ENV_VAR, self.sh_client_id)
-            self.sh_client_secret = self._override_with_env_var(SH_CLIENT_SECRET_ENV_VAR, self.sh_client_secret)
-
-    @staticmethod
-    def _override_with_env_var(env_var_name: str, default_value: str) -> str:
-        env_value = os.environ.get(env_var_name)
-        if env_value is None:
-            return default_value
-        # make sure you don't log the value!
-        LOGGER.debug("Overriding settings with environment variable %s.", env_var_name)
-        return env_value
+            self.sh_client_id = os.environ.get(SH_CLIENT_ID_ENV_VAR, default=self.sh_client_id)
+            self.sh_client_secret = os.environ.get(SH_CLIENT_SECRET_ENV_VAR, default=self.sh_client_secret)
 
     def _validate_values(self) -> None:
         """Ensures that the values are aligned with expectations."""

--- a/sentinelhub/config.py
+++ b/sentinelhub/config.py
@@ -29,9 +29,9 @@ class SHConfig:  # pylint: disable=too-many-instance-attributes
 
         - `instance_id`: An instance ID for Sentinel Hub service used for OGC requests.
         - `sh_client_id`: User's OAuth client ID for Sentinel Hub service. Can be set via SH_CLIENT_ID environment
-          variable.
+          variable. The environment variable has precedence.
         - `sh_client_secret`: User's OAuth client secret for Sentinel Hub service. Can be set via SH_CLIENT_SECRET
-          environment variable.
+          environment variable. The environment variable has precedence.
         - `sh_base_url`: There exist multiple deployed instances of Sentinel Hub service, this parameter defines the
           location of a specific service instance.
         - `sh_auth_base_url`: Base url for Sentinel Hub Authentication service. Authentication is typically sent to the
@@ -117,7 +117,7 @@ class SHConfig:  # pylint: disable=too-many-instance-attributes
         self.download_timeout_seconds: float = 120.0
         self.number_of_download_processes: int = 1
 
-        profile = self._override_with_environment(SH_PROFILE_ENV_VAR, profile)
+        profile = self._override_with_env_var(SH_PROFILE_ENV_VAR, profile)
 
         if not use_defaults:
             # load from config.toml
@@ -126,14 +126,15 @@ class SHConfig:  # pylint: disable=too-many-instance-attributes
                 setattr(self, param, getattr(loaded_instance, param))
 
             # check env
-            self.sh_client_id = self._override_with_environment(SH_CLIENT_ID_ENV_VAR, self.sh_client_id)
-            self.sh_client_secret = self._override_with_environment(SH_CLIENT_SECRET_ENV_VAR, self.sh_client_secret)
+            self.sh_client_id = self._override_with_env_var(SH_CLIENT_ID_ENV_VAR, self.sh_client_id)
+            self.sh_client_secret = self._override_with_env_var(SH_CLIENT_SECRET_ENV_VAR, self.sh_client_secret)
 
     @staticmethod
-    def _override_with_environment(env_var_name: str, default_value: str) -> str:
+    def _override_with_env_var(env_var_name: str, default_value: str) -> str:
         env_value = os.environ.get(env_var_name)
         if env_value is None:
             return default_value
+        # make sure you don't log the value!
         LOGGER.debug("Overriding settings with environment variable %s.", env_var_name)
         return env_value
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -102,6 +102,7 @@ def test_save(restore_config_file: None) -> None:
 
 @pytest.mark.dependency(depends=["test_user_config_is_masked"])
 def test_environment_variables(restore_config_file: None, monkeypatch) -> None:
+    """We use `monkeypatch` to avoid modifying global environment."""
     config = SHConfig()
     config.sh_client_id = "beepbeep"
     config.sh_client_secret = "imasheep"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -8,6 +8,7 @@ from typing import Generator
 import pytest
 
 from sentinelhub import SHConfig
+from sentinelhub.config import DEFAULT_PROFILE, SH_CLIENT_ID_ENV_VAR, SH_CLIENT_SECRET_ENV_VAR, SH_PROFILE_ENV_VAR
 
 
 @pytest.fixture(autouse=True, scope="module")
@@ -35,9 +36,11 @@ def switch_and_restore_config() -> Generator[None, None, None]:
 @pytest.fixture(name="restore_config_file")
 def restore_config_file_fixture() -> Generator[None, None, None]:
     """A fixture that ensures the config file is reset after the test."""
-    old_config = SHConfig()
+    with open(SHConfig.get_config_location()) as file:
+        content = file.read()
     yield
-    old_config.save()
+    with open(SHConfig.get_config_location(), "w") as file:
+        file.write(content)
 
 
 @pytest.fixture(name="dummy_config")
@@ -98,6 +101,21 @@ def test_save(restore_config_file: None) -> None:
 
 
 @pytest.mark.dependency(depends=["test_user_config_is_masked"])
+def test_environment_variables(restore_config_file: None, monkeypatch) -> None:
+    config = SHConfig()
+    config.sh_client_id = "beepbeep"
+    config.sh_client_secret = "imasheep"
+    config.save()
+
+    monkeypatch.setenv(SH_CLIENT_ID_ENV_VAR, "beekeeper")
+    monkeypatch.setenv(SH_CLIENT_SECRET_ENV_VAR, "bees-are-very-friendly")
+
+    config = SHConfig()
+    assert config.sh_client_id == "beekeeper"
+    assert config.sh_client_secret == "bees-are-very-friendly"
+
+
+@pytest.mark.dependency(depends=["test_user_config_is_masked"])
 def test_profiles(restore_config_file: None) -> None:
     config = SHConfig()
     config.instance_id = "beepbeep"
@@ -115,6 +133,21 @@ def test_profiles(restore_config_file: None) -> None:
     assert SHConfig(profile="beep").instance_id == "beepbeep"
     beep_config.save(profile="beep")
     assert SHConfig(profile="beep").instance_id == "bap"
+
+
+@pytest.mark.dependency(depends=["test_user_config_is_masked"])
+def test_profiles_from_env(restore_config_file: None, monkeypatch) -> None:
+    """We use `monkeypatch` to avoid modifying global environment."""
+    config = SHConfig()
+    config.instance_id = "bee"
+    config.save(profile="beekeeper")
+
+    assert SHConfig("beekeeper").instance_id == "bee"
+    assert SHConfig().instance_id == ""
+
+    monkeypatch.setenv(SH_PROFILE_ENV_VAR, "beekeeper")
+    assert SHConfig().instance_id == "bee", "Environment profile is not used."
+    assert SHConfig(profile=DEFAULT_PROFILE).instance_id == "bee", "Environment should override explicit profile."
 
 
 def test_loading_unknown_profile_fails() -> None:


### PR DESCRIPTION
- environment has precedence over everything
- for now only PROFILE, CLIENT_ID and CLIENT_SECRET can be set in environment. If there will be a need for more, we can add them later
- whenever a setting is overridden by the environment, I added a debug log. I am not sure if this is necessary (it would shorten the code if not).