### PR TITLE
Enable releasing as a wheel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,11 +11,11 @@ reset-config:
 
 upload:
 	rm -r dist | true
-	$(PYTHON) setup.py sdist
+	$(PYTHON) setup.py sdist bdist_wheel
 	twine upload --skip-existing dist/*
 
 # For testing:
 test-upload:
 	rm -r dist | true
-	$(PYTHON) setup.py sdist
+	$(PYTHON) setup.py sdist bdist_wheel
 	twine upload --repository testpypi --skip-existing dist/*


### PR DESCRIPTION
We didn't allow wheel releases because of the `config.json` file in the repo (and the fear of non-persistence, which didn't even work anyway).

Now nothing is holding us back.