### PR TITLE
Remove the reset functionality of SHConfig

### DIFF
--- a/sentinelhub/commands.py
+++ b/sentinelhub/commands.py
@@ -38,10 +38,9 @@ def _config_options(func: FC) -> FC:
 
 @click.command()
 @click.option("--show", is_flag=True, default=False, help="Show current configuration")
-@click.option("--reset", is_flag=True, default=False, help="Reset configuration to initial state")
 @click.option("--profile", default=DEFAULT_PROFILE, help="Selects profile to show/configure.")
 @_config_options
-def config(show: bool, reset: bool, profile: str, **params: Any) -> None:
+def config(show: bool, profile: str, **params: Any) -> None:
     """Inspect and configure parameters in your local sentinelhub configuration file
 
     \b
@@ -52,9 +51,6 @@ def config(show: bool, reset: bool, profile: str, **params: Any) -> None:
     """
     sh_config = SHConfig(profile=profile)
     old_config = sh_config.copy()
-
-    if reset:
-        sh_config.reset()
 
     for param, value in params.items():
         if value is not None:

--- a/sentinelhub/config.py
+++ b/sentinelhub/config.py
@@ -8,7 +8,7 @@ import json
 import numbers
 import os
 from pathlib import Path
-from typing import Dict, Iterable, Optional, Tuple, Union
+from typing import Dict, Optional, Tuple, Union
 
 import tomli
 import tomli_w
@@ -223,33 +223,6 @@ class SHConfig:  # pylint: disable=too-many-instance-attributes
     def copy(self) -> SHConfig:
         """Makes a copy of an instance of `SHConfig`"""
         return copy.copy(self)
-
-    def reset(self, params: Union[str, Iterable[str], object] = ...) -> None:
-        """Resets configuration class to default values. Does not save unless the `save` method is called afterwards.
-
-        Parameters can be specified as a list of names, e.g. ``['instance_id', 'aws_access_key_id']``, or as a single
-        name, e.g. ``'sh_base_url'``. By default, all parameters will be reset.
-
-        :param params: Parameters to reset to default values.
-        """
-        default_config = SHConfig(use_defaults=True)
-
-        if params is ...:
-            params = self.get_params()
-        elif isinstance(params, str):
-            params = [params]
-
-        if isinstance(params, Iterable):
-            for param in params:
-                self._reset_param(param, default_config)
-        else:
-            raise ValueError(f"Parameters must be a list of strings or as a single string, got {params}")
-
-    def _reset_param(self, param: str, default_config: SHConfig) -> None:
-        """Resets a single parameter."""
-        if param not in self.get_params():
-            raise ValueError(f"Cannot reset unknown parameter `{param}`")
-        setattr(self, param, getattr(default_config, param))
 
     @classmethod
     def get_params(cls) -> Tuple[str, ...]:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -67,20 +67,6 @@ def test_config_file_exists() -> None:
 
 
 @pytest.mark.dependency(depends=["test_user_config_is_masked"])
-def test_set_and_reset_value(dummy_config: SHConfig) -> None:
-    new_value = "new_instance_id"
-    dummy_config.instance_id = new_value
-    assert dummy_config.instance_id == new_value
-
-    dummy_config.reset("sh_base_url")
-    dummy_config.reset(["aws_access_key_id", "aws_secret_access_key"])
-    assert dummy_config.instance_id == new_value, "Instance ID should not reset yet"
-
-    dummy_config.reset()
-    assert dummy_config.instance_id == ""
-
-
-@pytest.mark.dependency(depends=["test_user_config_is_masked"])
 def test_save(restore_config_file: None) -> None:
     config = SHConfig()
     old_value = config.download_timeout_seconds


### PR DESCRIPTION
Before it was used for two things:
1. The config had to be reset before release in order to avoid leaking credentials
2. The user maybe wanted a fresh set of configuration? Or reset some to defaults?

Now these issues are solved:
1. The file is not part of the repo, its incredibly unlikely to release it.
2. With user profiles the user can just create a new profile. And since settings in the profile only override, you can just remove lines for parameters that you no longer wish to be non-default.