### PR TITLE
Adapt Config to be a dataclass

### DIFF
--- a/sentinelhub/commands.py
+++ b/sentinelhub/commands.py
@@ -31,7 +31,7 @@ def main_help() -> None:
 
 def _config_options(func: FC) -> FC:
     """A helper function which joins click.option functions of each parameter from config.json"""
-    for param in SHConfig().get_params()[-1::-1]:
+    for param in list(SHConfig().to_dict())[-1::-1]:
         func = click.option(f"--{param}", param, help=f"Set new values to configuration parameter `{param}`")(func)
     return func
 
@@ -66,12 +66,9 @@ def config(show: bool, profile: str, **params: Any) -> None:
 
     sh_config.save(profile=profile)
 
-    for param in sh_config.get_params():
-        value = getattr(sh_config, param)
+    for param, value in sh_config.to_dict(mask_credentials=False).items():
         if value != getattr(old_config, param):
-            if isinstance(value, str):
-                value = f"'{value}'"
-            click.echo(f"The value of parameter `{param}` was updated to {value}")
+            click.echo(f"The value of parameter `{param}` was updated to {repr(value)}")
 
     if show:
         unmasked_str_repr = json.dumps(sh_config.to_dict(mask_credentials=False), indent=2)

--- a/sentinelhub/config.py
+++ b/sentinelhub/config.py
@@ -49,7 +49,7 @@ class _SHConfig:
             raise ValueError("Value of config parameter `max_opensearch_records_per_query` must be at most 500")
 
 
-class SHConfig(_SHConfig):  # pylint: disable=too-many-instance-attributes
+class SHConfig(_SHConfig):
     """A sentinelhub-py package configuration class.
 
     The class reads the configurable settings from ``config.toml`` file on initialization:

--- a/tests/api/test_byoc.py
+++ b/tests/api/test_byoc.py
@@ -17,7 +17,7 @@ pytestmark = pytest.mark.sh_integration
 @pytest.fixture(name="config")
 def config_fixture() -> SHConfig:
     config = SHConfig()
-    for param in config.get_params():
+    for param in config.to_dict():
         env_variable = param.upper()
         if os.environ.get(env_variable):
             setattr(config, param, os.environ.get(env_variable))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,7 +20,7 @@ OUTPUT_FOLDER = get_output_folder(__file__)
 
 def pytest_configure(config: Config) -> None:
     shconfig = SHConfig()
-    for param in shconfig.get_params():
+    for param in shconfig.to_dict():
         env_variable = param.upper()
         if os.environ.get(env_variable):
             setattr(shconfig, param, os.environ.get(env_variable))

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -98,7 +98,18 @@ def test_environment_variables(restore_config_file: None, monkeypatch) -> None:
     assert config.sh_client_secret == "bees-are-very-friendly"
 
 
-# @pytest.mark.dependency(depends=["test_user_config_is_masked"])
+@pytest.mark.dependency(depends=["test_user_config_is_masked"])
+def test_initialization_with_params(monkeypatch) -> None:
+    loaded_config = SHConfig()
+    monkeypatch.setenv(SH_CLIENT_ID_ENV_VAR, "beekeeper")
+
+    config = SHConfig(sh_client_id="me", instance_id="beep", geopedia_wms_url="123")
+    assert config.instance_id == "beep"
+    assert config.geopedia_wms_url != loaded_config.geopedia_wms_url, "Does not override settings from config.toml"
+    assert config.sh_client_id == "beekeeper", "Overrides environment."
+
+
+@pytest.mark.dependency(depends=["test_user_config_is_masked"])
 def test_profiles(restore_config_file: None) -> None:
     config = SHConfig()
     config.instance_id = "beepbeep"


### PR DESCRIPTION
Also allows us switching to pydantic in the future :dagger: 

The only thing we need to fully agree on is wether `init params > env > config.toml` or `env > init params > config.toml`.
Previously `profile` was set so that env trumps all, which is why the rest of the params follow suit. 