### PR TITLE
Move evalscript generation to sh-py

### DIFF
--- a/sentinelhub/__init__.py
+++ b/sentinelhub/__init__.py
@@ -55,6 +55,7 @@ from .download import (
     SentinelHubSession,
     SentinelHubStatisticalDownloadClient,
 )
+from .evalscript import generate_evalscript, parse_data_collection_bands
 from .exceptions import AwsDownloadFailedException, DownloadFailedException
 from .geo_utils import (
     bbox_to_dimensions,

--- a/sentinelhub/evalscript.py
+++ b/sentinelhub/evalscript.py
@@ -1,0 +1,117 @@
+"""
+Module defining evalscript generation utilities
+"""
+from typing import Dict, List, Optional
+
+import numpy as np
+
+from .data_collections import DataCollection
+from .data_collections_bands import Band, Unit
+
+DTYPE_TO_SAMPLE_TYPE: Dict[type, str] = {
+    bool: "UINT8",
+    np.uint8: "UINT8",
+    np.uint16: "UINT16",
+    np.float32: "FLOAT32",
+}
+
+EVALSCRIPT_TEMPLATE = """
+    //VERSION=3
+
+    function setup() {{
+        return {{
+            input: [{{
+                bands: [{input_names}],
+                units: [{input_units}]
+            }}],
+            output: [{output_spec}]
+        }}
+    }}
+
+    function updateOutputMetadata(scenes, inputMetadata, outputMetadata) {{
+        outputMetadata.userData = {{
+            "norm_factor":  inputMetadata.normalizationFactor
+        }}
+    }}
+
+    function evaluatePixel(sample) {{
+        return {{ {return_spec} }};
+    }}
+"""
+
+
+def parse_data_collection_bands(data_collection: DataCollection, bands: List[str]) -> List[Band]:
+    """Checks that all requested bands are available and returns the band information for further processing
+
+    :param data_collection: A collection of requested satellite data.
+    :param bands: A list of band or meta band names to use in the evalscript.
+    """
+
+    requested_bands = []
+    band_info_dict = {band_info.name: band_info for band_info in data_collection.bands + data_collection.metabands}
+
+    for band_name in bands:
+        if band_name not in band_info_dict:
+            raise ValueError(
+                f"Data collection {data_collection} does not have specifications for band {band_name}.\n"
+                f"Available bands are:\n{[band.name for band in data_collection.bands]}\nand meta-bands:\n"
+                f"{[band.name for band in data_collection.metabands]}."
+            )
+        requested_bands.append(band_info_dict[band_name])
+
+    return requested_bands
+
+
+def generate_evalscript(
+    data_collection: DataCollection,
+    bands: Optional[List[str]] = None,
+    meta_bands: Optional[List[str]] = None,
+    merged_output: Optional[str] = None,
+    use_dn: bool = True,
+) -> str:
+    """Generate an evalscript based on the provided specifications. This utility supports generating only evalscripts
+    with the mosaicking option set to `SIMPLE`.
+
+    :param data_collection: A collection of requested satellite data.
+    :param bands: A list of band names to use in the evalscript. Defaults to using all bands provided by the collection.
+    :param bands: A list of meta band names to use in the evalscript. By default no meta bands are added.
+    :param merged_output: If provided, bands will be concatenated into a single multi-band tiff with this name.
+    :param use_dn: Use DN units if possible. Default is True. If DN units are not available, the default units for each
+        specific band are used. DN units will be used regardless of the flag if they are the only possible choice.
+    """
+
+    band_names = bands if bands is not None else [band.name for band in data_collection.bands]
+    meta_band_names = meta_bands if meta_bands is not None else []
+
+    input_names, input_units, output_spec, return_spec = [], [], [], []
+    requested_bands = parse_data_collection_bands(data_collection, band_names + meta_band_names)
+    for band in requested_bands:
+        unit_choice = band.units.index(Unit.DN) if (use_dn and Unit.DN in band.units) else 0
+        sample_type = DTYPE_TO_SAMPLE_TYPE[band.output_types[unit_choice]]
+
+        input_names.append(f'"{band.name}"')
+        input_units.append(f'"{band.units[unit_choice].value}"')
+
+        # skip bands, since they will be provided as a single object
+        if merged_output is not None and band.name in band_names:
+            continue
+
+        # keep for meta_bands
+        output_spec.append(f'{{ id: "{band.name}", bands: 1, sampleType: "{sample_type}" }}')
+        return_spec.append(f"{band.name}: [sample.{band.name}]")
+
+    if merged_output is not None:
+        band = data_collection.bands[0]
+        unit_choice = band.units.index(Unit.DN) if (use_dn and Unit.DN in band.units) else 0
+        sample_type = DTYPE_TO_SAMPLE_TYPE[band.output_types[unit_choice]]
+        output_spec.append(f'{{ id: "{merged_output}", bands: {len(band_names)}, sampleType: "{sample_type}" }}')
+        return_spec.append(f"{merged_output}: [{', '.join(f'sample.{band}' for band in band_names)}]")
+
+    evalscript = EVALSCRIPT_TEMPLATE.format(
+        input_names=", ".join(input_names),
+        input_units=", ".join(input_units),
+        output_spec=", ".join(output_spec),
+        return_spec=", ".join(return_spec),
+    )
+
+    return evalscript

--- a/tests/test_evalscript.py
+++ b/tests/test_evalscript.py
@@ -1,0 +1,105 @@
+import json
+import re
+from typing import List, Optional, Tuple
+
+import pytest
+
+from sentinelhub import DataCollection
+from sentinelhub.data_collections_bands import Unit
+from sentinelhub.evalscript import generate_evalscript
+
+
+def parse_evalscript_info(evalscript: str) -> Tuple[List[str], List[str], List[Tuple[str, str, str]]]:
+    input_names_re = re.search(r"bands: (\[.*\])", evalscript)
+    input_units_re = re.search(r"units: (\[.*\])", evalscript)
+    output_spec = re.findall(r'\{ id: "([^\s.]+)", bands: ([^\s.]+), sampleType: "([^\s.]+)" \}', evalscript)
+
+    assert input_names_re is not None, "regex failed for extraction of input names"
+    assert input_units_re is not None, "regex failed for extraction of input units"
+
+    input_names = json.loads(input_names_re.group(1))
+    input_units = json.loads(input_units_re.group(1))
+
+    return input_names, input_units, output_spec
+
+
+@pytest.mark.parametrize(
+    "data_collection, bands",
+    [
+        (DataCollection.SENTINEL2_L1C, None),
+        (DataCollection.SENTINEL2_L1C, ["B04", "B03", "B02"]),
+        (DataCollection.SENTINEL1_IW, ["VV", "VH"]),
+    ],
+)
+def test_input_bands(data_collection: DataCollection, bands: Optional[List[str]]) -> None:
+    evalscript = generate_evalscript(data_collection=data_collection, bands=bands)
+    input_names, *_ = parse_evalscript_info(evalscript)
+    assert len(input_names) == len(bands) if bands is not None else len(data_collection.bands)
+
+
+@pytest.mark.parametrize(
+    "meta_bands",
+    [None, ["CLM"], ["CLP", "dataMask"]],
+)
+def test_input_meta_bands(meta_bands: Optional[List[str]]) -> None:
+    data_collection = DataCollection.SENTINEL2_L1C
+    evalscript = generate_evalscript(data_collection=data_collection, meta_bands=meta_bands)
+    input_names, *_ = parse_evalscript_info(evalscript)
+
+    num_meta_bands = 0 if meta_bands is None else len(meta_bands)
+    assert len(input_names) == len(data_collection.bands) + num_meta_bands
+
+
+@pytest.mark.parametrize("use_dn", [True, False])
+@pytest.mark.parametrize(
+    "data_collection, bands, meta_bands",
+    [
+        (DataCollection.SENTINEL2_L1C, ["B04", "B03", "B02"], ["CLP", "sunZenithAngles"]),
+        (DataCollection.SENTINEL3_OLCI, ["B04", "B03"], ["HUMIDITY"]),
+    ],
+)
+def test_input_units(data_collection: DataCollection, bands: List[str], meta_bands: List[str], use_dn: bool) -> None:
+    evalscript = generate_evalscript(data_collection=data_collection, bands=bands, meta_bands=meta_bands, use_dn=use_dn)
+    input_names, input_units, _ = parse_evalscript_info(evalscript)
+
+    band_info_dict = {band_info.name: band_info for band_info in data_collection.bands + data_collection.metabands}
+    for name, unit in zip(input_names, input_units):
+        band = band_info_dict[name]
+        assert Unit(unit) in band.units
+
+        if use_dn and Unit.DN in band.units:
+            assert Unit(unit) == Unit.DN
+
+
+@pytest.mark.parametrize(
+    "data_collection, bands, meta_bands",
+    [
+        (DataCollection.LANDSAT_TM_L2, None, ["BQA"]),
+        (DataCollection.SENTINEL2_L2A, ["B04", "B03", "B02"], ["CLP", "SCL"]),
+    ],
+)
+def test_merged_output(data_collection: DataCollection, bands: Optional[List[str]], meta_bands: List[str]) -> None:
+    merged_output = "merged_bands"
+    evalscript = generate_evalscript(
+        data_collection=data_collection, bands=bands, meta_bands=meta_bands, merged_output=merged_output
+    )
+    *_, output_spec = parse_evalscript_info(evalscript)
+
+    num_bands = len(data_collection.bands) if bands is None else len(bands)
+    depth = [depth for name, depth, _ in output_spec if name == merged_output][0]
+
+    assert len(output_spec) == 1 + len(meta_bands)
+    assert int(depth) == num_bands
+
+
+@pytest.mark.parametrize("merged_output", [None, "merged_bands"])
+@pytest.mark.parametrize("use_dn", [True, False])
+def test_sample_type(merged_output: Optional[str], use_dn: bool) -> None:
+    data_collection = DataCollection.SENTINEL2_L1C
+    evalscript = generate_evalscript(data_collection=data_collection, merged_output=merged_output, use_dn=use_dn)
+
+    *_, output_spec = parse_evalscript_info(evalscript)
+    assert len(output_spec) == 1 if merged_output else len(data_collection.bands)
+
+    sample_types_set = {sample_type for *_, sample_type in output_spec}
+    assert sample_types_set == {"UINT16" if use_dn else "FLOAT32"}


### PR DESCRIPTION
Changes:
- move utility from https://github.com/sentinel-hub/eo-learn/blob/develop/io/eolearn/io/sentinelhub_process.py#L478 to this repo
- add tests

The evalscript generation is simple in nature, and offers the following:
- limited to `SIMPLE` mosaicking
- only download bands (separate or merged into a single output)
- use DN or not (if available)
- provide a subset of bands/meta_bands