### PR TITLE
Minor indentation and parameter default fixes

### DIFF
--- a/sentinelhub/api/catalog.py
+++ b/sentinelhub/api/catalog.py
@@ -275,7 +275,7 @@ def get_available_timestamps(
     *,
     time_difference: Optional[dt.timedelta] = None,
     ignore_tz: bool = True,
-    maxcc: Optional[float] = 1.0,
+    maxcc: Optional[float] = None, 
     config: Optional[SHConfig] = None,
 ) -> List[dt.datetime]:
     """Helper function to search for all available timestamps for a given area and query parameters.

--- a/sentinelhub/api/catalog.py
+++ b/sentinelhub/api/catalog.py
@@ -275,7 +275,7 @@ def get_available_timestamps(
     *,
     time_difference: Optional[dt.timedelta] = None,
     ignore_tz: bool = True,
-    maxcc: Optional[float] = None, 
+    maxcc: Optional[float] = None,
     config: Optional[SHConfig] = None,
 ) -> List[dt.datetime]:
     """Helper function to search for all available timestamps for a given area and query parameters.

--- a/sentinelhub/evalscript.py
+++ b/sentinelhub/evalscript.py
@@ -16,27 +16,27 @@ DTYPE_TO_SAMPLE_TYPE: Dict[type, str] = {
 }
 
 EVALSCRIPT_TEMPLATE = """
-    //VERSION=3
+//VERSION=3
 
-    function setup() {{
-        return {{
-            input: [{{
-                bands: [{input_names}],
-                units: [{input_units}]
-            }}],
-            output: [{output_spec}]
-        }}
+function setup() {{
+    return {{
+        input: [{{
+            bands: [{input_names}],
+            units: [{input_units}]
+        }}],
+        output: [{output_spec}]
     }}
+}}
 
-    function updateOutputMetadata(scenes, inputMetadata, outputMetadata) {{
-        outputMetadata.userData = {{
-            "norm_factor":  inputMetadata.normalizationFactor
-        }}
+function updateOutputMetadata(scenes, inputMetadata, outputMetadata) {{
+    outputMetadata.userData = {{
+        "norm_factor":  inputMetadata.normalizationFactor
     }}
+}}
 
-    function evaluatePixel(sample) {{
-        return {{ {return_spec} }};
-    }}
+function evaluatePixel(sample) {{
+    return {{ {return_spec} }};
+}}
 """
 
 


### PR DESCRIPTION
Nothing major, just minor changes due to some faulty revert in the past:
- fix `get_available_timestamps` function parameter default
- fix indentation in evalscript template