### PR TITLE
Remove codecov dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,6 @@ dev = [
     "boto3-stubs>=1.20.0",
     "build",
     "click>=8.0.0",
-    "codecov",
     "fs",
     "mypy>=0.990",
     "moto",


### PR DESCRIPTION
It has been removed from the PyPI. Our builds are failing but it looks like it's not needed anywhere.