### PR TITLE
Official Python 3.11 support

### DIFF
--- a/.github/workflows/ci_action.yml
+++ b/.github/workflows/ci_action.yml
@@ -67,6 +67,7 @@ jobs:
         python-version:
           - "3.9"
           - "3.10"
+          - "3.11"
         include:
           # A flag marks whether full or partial tests should be run
           # We don't run integration tests on pull requests from outside repos, because they don't have secrets

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Topic :: Scientific/Engineering",
     "Topic :: Software Development",
 ]

--- a/sentinelhub/data_collections.py
+++ b/sentinelhub/data_collections.py
@@ -2,13 +2,17 @@
 Module defining data collections
 """
 from dataclasses import dataclass, field, fields
-from enum import Enum, EnumMeta
-from typing import Any, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
 from aenum import extend_enum
 
 from .constants import ServiceUrl
 from .data_collections_bands import Band, Bands, MetaBands
+
+if TYPE_CHECKING:
+    from enum import Enum, EnumMeta  # mypy has a custom plugin for enum but not aenum
+else:
+    from aenum import Enum, EnumMeta
 
 
 class _CollectionType:


### PR DESCRIPTION
Extending enums is problematic in 3.11, probably because the official implementation of Enums got upgraded in some ways.
If we use the class from `aenum` then it seems to work. Tests in eo-grow and eo-learn pass with this as well.