### PR TITLE
Add pip cache to CI actions

### DIFF
--- a/.github/workflows/ci_action.yml
+++ b/.github/workflows/ci_action.yml
@@ -48,7 +48,7 @@ jobs:
           cache: pip
 
       - name: Install packages
-        run: pip install -e .[AWS,DEV]
+        run: pip install --upgrade --upgrade-strategy eager -e .[AWS,DEV]
 
       - name: Run mypy
         run: mypy sentinelhub
@@ -86,7 +86,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y build-essential libgdal-dev proj-bin gcc libproj-dev libspatialindex-dev libopenjp2-7
-          pip install -e .[AWS,DEV]
+          pip install --upgrade --upgrade-strategy eager -e .[AWS,DEV]
 
       - name: Run full tests and code coverage
         if: ${{ matrix.full_test_suite }}

--- a/.github/workflows/ci_action.yml
+++ b/.github/workflows/ci_action.yml
@@ -19,37 +19,33 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ env.CHECKOUT_BRANCH }}
 
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: "3.8"
-          architecture: x64
+          cache: pip
 
-      - name: Prepare pre-commit validators
-        run: |
-          pip install pre-commit
-          pre-commit install
-
-      - name: Check code compliance with pre-commit validators
-        run: pre-commit run --all-files
+      - uses: pre-commit/action@v3.0.0
+        with:
+          extra_args: --all-files --verbose
 
   check-code-pylint-and-mypy:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ env.CHECKOUT_BRANCH }}
 
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: "3.8"
-          architecture: x64
+          cache: pip
 
       - name: Install packages
         run: pip install -e .[AWS,DEV]
@@ -76,15 +72,15 @@ jobs:
             full_test_suite: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     steps:
       - name: Checkout branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ env.CHECKOUT_BRANCH }}
 
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-          architecture: x64
+          cache: pip
 
       - name: Install packages
         run: |

--- a/.github/workflows/ci_action.yml
+++ b/.github/workflows/ci_action.yml
@@ -11,7 +11,7 @@ on:
     - cron: "5 0 * * *"
 
 concurrency:
-  # This will cancel outdated runs on the same pull-request, but wont touch runs for other triggers
+  # This will cancel outdated runs on the same pull-request, but not runs for other triggers
   group: ${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 

--- a/.github/workflows/ci_action.yml
+++ b/.github/workflows/ci_action.yml
@@ -83,10 +83,7 @@ jobs:
           cache: pip
 
       - name: Install packages
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y build-essential libgdal-dev proj-bin gcc libproj-dev libspatialindex-dev libopenjp2-7
-          pip install --upgrade --upgrade-strategy eager -e .[AWS,DEV]
+        run: pip install --upgrade --upgrade-strategy eager -e .[AWS,DEV]
 
       - name: Run full tests and code coverage
         if: ${{ matrix.full_test_suite }}

--- a/.github/workflows/ci_action.yml
+++ b/.github/workflows/ci_action.yml
@@ -10,6 +10,11 @@ on:
     # Schedule events are triggered by whoever last changed the cron schedule
     - cron: "5 0 * * *"
 
+concurrency:
+  # This will cancel outdated runs on the same pull-request, but wont touch runs for other triggers
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 env:
   # The only way to simulate if-else statement
   CHECKOUT_BRANCH: ${{ github.event_name == 'schedule' && 'develop' || github.ref }}


### PR DESCRIPTION
Improves the CI in the following ways:
- updated versions of actions
- use pre-commit action instead of doing it manually (seems to be faster, probably caching)
- add caching to python-setup action, this makes installation about 30% faster since most packages do not need to be downloaded (allegedly you can cache the whole python environment and gain some more speedup, but it requires another action)
- removed installation of non-python stuff, doesn't seem to affect our tests but makes installation 30% faster
- add `concurrency` option, which makes sure that whenever a PR is updated (a new commit) it cancels all outdated CI workflows, saving resources in cases where a 'quick fix' commit is added (for instance if the pre-commit complains)

Shaves off about 1min for all jobs on average :D
