### PR TITLE
Added QUALITY_FLAGS band to S3_OLCI

### DIFF
--- a/sentinelhub/data_collections_bands.py
+++ b/sentinelhub/data_collections_bands.py
@@ -164,6 +164,7 @@ class MetaBands:
         Band("HUMIDITY", (Unit.PERCENT,), (np.float32,)),
         Band("SEA_LEVEL_PRESSURE", (Unit.HECTOPASCALS,), (np.float32,)),
         *(Band(name, (Unit.KG_M2,), (np.float32,)) for name in ["TOTAL_COLUMN_OZONE", "TOTAL_COLUMN_WATER_VAPOUR"]),
+        Band("QUALITY_FLAGS", (Unit.DN,), (np.uint32,)),
         Band("dataMask", (Unit.DN,), (bool,)),
     )
     SENTINEL3_SLSTR = (Band("dataMask", (Unit.DN,), (bool,)),)


### PR DESCRIPTION
This adds the `QUALITY_FLAGS` S3_OLCI band to `MetaBands`

See docs for band description: https://docs.sentinel-hub.com/api/latest/data/sentinel-3-olci-l1b/#units