### PR TITLE
Config no longer falsely loads profiles if file doesn't exist

### DIFF
--- a/sentinelhub/config.py
+++ b/sentinelhub/config.py
@@ -149,13 +149,13 @@ class SHConfig(_SHConfig):
         """
         filename = cls.get_config_location()
         if not os.path.exists(filename):
-            cls(use_defaults=True).save(profile)  # store default configuration to standard location
+            cls(use_defaults=True).save()  # store default configuration to standard location
 
         with open(filename, "rb") as cfg_file:
             configurations_dict = tomli.load(cfg_file)
 
         if profile not in configurations_dict:
-            raise KeyError(f"Profile {profile} not found in configuration file.")
+            raise KeyError(f"Profile `{profile}` not found in configuration file.")
 
         return cls(use_defaults=True, **configurations_dict[profile])
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -136,6 +136,20 @@ def test_profiles() -> None:
 
 @pytest.mark.dependency(depends=["test_user_config_is_masked"])
 @pytest.mark.usefixtures("_restore_config_file")
+def test_initialize_nondefault_profile() -> None:
+    """Since there is no config, loading a non-default profile should fail."""
+    config = SHConfig()
+    os.remove(config.get_config_location())
+
+    SHConfig()  # works for default
+
+    os.remove(config.get_config_location())
+    with pytest.raises(KeyError):
+        SHConfig("mr_president")
+
+
+@pytest.mark.dependency(depends=["test_user_config_is_masked"])
+@pytest.mark.usefixtures("_restore_config_file")
 def test_profiles_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
     """We use `monkeypatch` to avoid modifying global environment."""
     config = SHConfig()


### PR DESCRIPTION
As noticed by you, if the file doesn't exist one could do the first initialization with `SHConfig("something")` and break the whole damn thing.

I added a test that now the first init fails for any non-default profile (since no such profile exists).