### PR TITLE
Make sh-config CLI use environmental variable

### DIFF
--- a/sentinelhub/commands.py
+++ b/sentinelhub/commands.py
@@ -9,7 +9,7 @@ from typing import Any, Callable, TypeVar
 
 import click
 
-from .config import DEFAULT_PROFILE, SHConfig
+from .config import SHConfig
 from .download import DownloadClient, DownloadRequest
 
 FC = TypeVar("FC", bound=Callable[..., Any])
@@ -40,9 +40,9 @@ def _config_options(func: FC) -> FC:
 
 @click.command()
 @click.option("--show", is_flag=True, default=False, help="Show current configuration")
-@click.option("--profile", default=DEFAULT_PROFILE, help="Selects profile to show/configure.")
+@click.option("--profile", default=None, help="Selects profile to show/configure.")
 @_config_options
-def config(show: bool, profile: str, **params: Any) -> None:
+def config(show: bool, profile: str | None, **params: Any) -> None:
     """Inspect and configure parameters in your local sentinelhub configuration file
 
     \b
@@ -65,8 +65,6 @@ def config(show: bool, profile: str, **params: Any) -> None:
                     value = False
             if getattr(sh_config, param) != value:
                 setattr(sh_config, param, value)
-
-    sh_config.save(profile=profile)
 
     for param, value in sh_config.to_dict(mask_credentials=False).items():
         if value != getattr(old_config, param):

--- a/sentinelhub/commands.py
+++ b/sentinelhub/commands.py
@@ -66,6 +66,8 @@ def config(show: bool, profile: str | None, **params: Any) -> None:
             if getattr(sh_config, param) != value:
                 setattr(sh_config, param, value)
 
+    sh_config.save(profile=profile)
+
     for param, value in sh_config.to_dict(mask_credentials=False).items():
         if value != getattr(old_config, param):
             click.echo(f"The value of parameter `{param}` was updated to {value!r}")

--- a/sentinelhub/config.py
+++ b/sentinelhub/config.py
@@ -114,8 +114,7 @@ class SHConfig(_SHConfig):
         :param use_defaults: Does not load the configuration file, returns config object with defaults only.
         :param kwargs: Any fields of `SHConfig` to be updated. Overrides settings from `config.toml` and environment.
         """
-        if profile is None:
-            profile = os.environ.get(SH_PROFILE_ENV_VAR, default=DEFAULT_PROFILE)
+        profile = self._get_profile(profile)
 
         if not use_defaults:
             env_kwargs = {
@@ -141,12 +140,17 @@ class SHConfig(_SHConfig):
         content = ",\n  ".join(f"{key}={value!r}" for key, value in config_dict.items())
         return f"{self.__class__.__name__}(\n  {content},\n)"
 
+    @staticmethod
+    def _get_profile(profile: str | None) -> str:
+        return profile if profile is not None else os.environ.get(SH_PROFILE_ENV_VAR, default=DEFAULT_PROFILE)
+
     @classmethod
-    def load(cls, profile: str = DEFAULT_PROFILE) -> SHConfig:
+    def load(cls, profile: str | None = None) -> SHConfig:
         """Loads configuration parameters from the config file at `SHConfig.get_config_location()`.
 
         :param profile: Which profile to load from the configuration file.
         """
+        profile = cls._get_profile(profile)
         filename = cls.get_config_location()
         if not os.path.exists(filename):
             cls(use_defaults=True).save(profile)  # store default configuration to standard location
@@ -159,11 +163,12 @@ class SHConfig(_SHConfig):
 
         return cls(use_defaults=True, **configurations_dict[profile])
 
-    def save(self, profile: str = DEFAULT_PROFILE) -> None:
+    def save(self, profile: str | None = None) -> None:
         """Saves configuration parameters to the config file at `SHConfig.get_config_location()`.
 
         :param profile: Under which profile to save the configuration.
         """
+        profile = self._get_profile(profile)
         file_path = Path(self.get_config_location())
         file_path.parent.mkdir(parents=True, exist_ok=True)
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -147,7 +147,15 @@ def test_profiles_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
 
     monkeypatch.setenv(SH_PROFILE_ENV_VAR, "beekeeper")
     assert SHConfig().instance_id == "bee", "Environment profile is not used."
+    assert SHConfig.load().instance_id == "bee", "The load method does not respect the environment profile."
     assert SHConfig(profile=DEFAULT_PROFILE).instance_id == "", "Explicit profile overrides environment."
+
+    config = SHConfig()
+    config.instance_id = "many bee"
+    config.save()
+
+    assert SHConfig(profile="beekeeper").instance_id == "many bee", "Save method does not respect the env profile."
+    assert SHConfig(profile=DEFAULT_PROFILE).instance_id == "", "Saving with env profile changed default profile."
 
 
 def test_loading_unknown_profile_fails() -> None:


### PR DESCRIPTION
~the saving is also unnecessary because the load method creates the file if needed~

saving is needed because we have one do-all command. Gotta figure this out