### PR TITLE
Fix bug that occurs with dataclass_json 0.62

### DIFF
--- a/sentinelhub/api/byoc.py
+++ b/sentinelhub/api/byoc.py
@@ -47,7 +47,7 @@ class ByocCollectionAdditionalData:
     other_data: CatchAll = field(default_factory=dict)
 
 
-@dataclass_json(letter_case=LetterCase.CAMEL, undefined=Undefined.INCLUDE)
+@dataclass_json(letter_case=LetterCase.CAMEL)
 @dataclass
 class ByocCollection(BaseCollection):
     """Dataclass to hold BYOC collection data"""

--- a/sentinelhub/api/utils.py
+++ b/sentinelhub/api/utils.py
@@ -21,7 +21,7 @@ datetime_config = dataclass_config(
     letter_case=LetterCase.CAMEL,
 )
 
-geometry_config = dataclass_config(  # type: ignore[misc]
+geometry_config = dataclass_config(
     encoder=Geometry.get_geojson,
     decoder=lambda geojson: Geometry.from_geojson(geojson) if geojson else None,
     exclude=lambda geojson: geojson is None,
@@ -31,7 +31,7 @@ geometry_config = dataclass_config(  # type: ignore[misc]
 
 def enum_config(enum_class: Type[Enum]) -> Dict[str, dict]:
     """Given an Enum class it provide an object for serialization/deserialization"""
-    return dataclass_config(  # type: ignore[misc]
+    return dataclass_config(
         encoder=lambda enum_item: enum_item.value,
         decoder=lambda item: enum_class(item) if item else None,
         exclude=lambda item: item is None,

--- a/sentinelhub/geometry.py
+++ b/sentinelhub/geometry.py
@@ -6,7 +6,7 @@ import contextlib
 import warnings
 from abc import ABCMeta, abstractmethod
 from math import ceil
-from typing import Callable, Dict, Iterator, Tuple, TypeVar, Union, cast
+from typing import Callable, Dict, Iterator, Tuple, TypeVar, Union
 
 import shapely.geometry
 import shapely.geometry.base
@@ -159,9 +159,9 @@ class BBox(_BaseGeometry):
         :raises: TypeError
         """
         if len(bbox) == 4:
-            min_x, min_y, max_x, max_y = cast(Tuple[float, float, float, float], bbox)
+            min_x, min_y, max_x, max_y = bbox
         else:
-            (min_x, min_y), (max_x, max_y) = cast(Tuple[Tuple[float, float], Tuple[float, float]], bbox)
+            (min_x, min_y), (max_x, max_y) = bbox
         return float(min_x), float(min_y), float(max_x), float(max_y)
 
     @staticmethod


### PR DESCRIPTION
The issue happens when someone calls the `to_dict` method on the collection.
Sadly this is used in our code a lot :upside_down_face: would you consider this worthy of a release? 