### PR TITLE
Deprecate the deprecator

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
         language_version: python3
 
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: "v0.1.1"
+    rev: "v0.1.3"
     hooks:
       - id: ruff
 

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,9 +1,17 @@
+## [Version 3.9.3] - 2023-11-03
+
+- `SHConfig` now correctly initializes a default profile in the file even if the first initialization call is done with a custom profile.
+- Save and load methods of `SHConfig` adjusted to work with the environmental variable `SH_PROFILE`
+- CLI command `sentinelhub.config --show` works with the environmental variable `SH_PROFILE`
+
+
 ## [Version 3.9.2] - 2023-10-24
 
 - Adjusted how user credentials are passed to the OAuth service.
 - Added `QUALITY_FLAGS` band to `S3_OLCI`
 - Batch statistical API now supports IAM role style credentials.
 - Various minor improvements
+
 
 ## [Version 3.9.1] - 2023-05-04
 

--- a/sentinelhub/_version.py
+++ b/sentinelhub/_version.py
@@ -1,3 +1,3 @@
 """Version of the sentinelhub package."""
 
-__version__ = "3.9.2"
+__version__ = "3.9.3"

--- a/sentinelhub/api/batch/statistical.py
+++ b/sentinelhub/api/batch/statistical.py
@@ -12,8 +12,9 @@ from typing import Any, Optional, Sequence, Union
 
 from dataclasses_json import CatchAll, LetterCase, Undefined, dataclass_json
 from dataclasses_json import config as dataclass_config
+from typing_extensions import deprecated
 
-from ...exceptions import deprecated_function
+from ...exceptions import SHDeprecationWarning
 from ...types import Json, JsonDict
 from ..base_request import InputDataDict
 from ..statistical import SentinelHubStatistical
@@ -140,7 +141,7 @@ class SentinelHubBatchStatistical(BaseBatchClient["BatchStatisticalRequest"]):
         """
         return self._call_job(batch_request, "start")
 
-    @deprecated_function(message_suffix="The service endpoint will be removed soon. Please use `stop_job` instead.")
+    @deprecated("The method `cancel_job` has been replaced with use `stop_job`.", category=SHDeprecationWarning)
     def cancel_job(self, batch_request: BatchStatisticalRequestType) -> Json:
         """Cancels a batch job
 

--- a/sentinelhub/aws/client.py
+++ b/sentinelhub/aws/client.py
@@ -5,6 +5,7 @@ Module implementing a download client that is adjusted to download from AWS
 import logging
 import warnings
 from typing import Any, Dict, Optional
+from typing_extensions import deprecated
 
 try:
     from boto3 import Session
@@ -18,12 +19,15 @@ from ..config import SHConfig
 from ..download.client import DownloadClient
 from ..download.handlers import fail_missing_file
 from ..download.models import DownloadRequest, DownloadResponse
-from ..exceptions import AwsDownloadFailedException, deprecated_class
+from ..exceptions import AwsDownloadFailedException, SHDeprecationWarning
 
 LOGGER = logging.getLogger(__name__)
 
 
-@deprecated_class(message_suffix="It will remain in the codebase for now, but won't be actively maintained.")
+@deprecated(
+    "AWS functionality will remain in the codebase for now, but won't be actively maintained.",
+    category=SHDeprecationWarning,
+)
 class AwsDownloadClient(DownloadClient):
     """An AWS download client class"""
 

--- a/sentinelhub/aws/data.py
+++ b/sentinelhub/aws/data.py
@@ -7,13 +7,14 @@ import os
 import warnings
 from abc import ABCMeta, abstractmethod
 from typing import Any, List, Optional, Tuple, Union
+from typing_extensions import deprecated
 
 from ..api.opensearch import get_tile_info, get_tile_info_id
 from ..config import SHConfig
 from ..constants import MimeType
 from ..data_collections import DataCollection
 from ..download import DownloadRequest
-from ..exceptions import AwsDownloadFailedException, SHUserWarning, deprecated, SHDeprecationWarning
+from ..exceptions import AwsDownloadFailedException, SHUserWarning, SHDeprecationWarning
 from ..time_utils import parse_time
 from .client import AwsDownloadClient
 from .constants import AwsConstants, EsaSafeType

--- a/sentinelhub/aws/data.py
+++ b/sentinelhub/aws/data.py
@@ -13,7 +13,7 @@ from ..config import SHConfig
 from ..constants import MimeType
 from ..data_collections import DataCollection
 from ..download import DownloadRequest
-from ..exceptions import AwsDownloadFailedException, SHUserWarning, deprecated_class
+from ..exceptions import AwsDownloadFailedException, SHUserWarning, deprecated, SHDeprecationWarning
 from ..time_utils import parse_time
 from .client import AwsDownloadClient
 from .constants import AwsConstants, EsaSafeType
@@ -320,7 +320,10 @@ class AwsData(metaclass=ABCMeta):
         )
 
 
-@deprecated_class(message_suffix="It will remain in the codebase for now, but won't be actively maintained.")
+@deprecated(
+    "AWS functionality will remain in the codebase for now, but won't be actively maintained.",
+    category=SHDeprecationWarning,
+)
 class AwsProduct(AwsData):
     """Class for collecting Sentinel-2 products data from AWS."""
 
@@ -468,7 +471,10 @@ class AwsProduct(AwsData):
         return os.path.join(self.parent_folder, self.product_id, self.add_file_extension(filename)).replace(":", ".")
 
 
-@deprecated_class(message_suffix="It will remain in the codebase for now, but won't be actively maintained.")
+@deprecated(
+    "AWS functionality will remain in the codebase for now, but won't be actively maintained.",
+    category=SHDeprecationWarning,
+)
 class AwsTile(AwsData):
     """Class for collecting Sentinel-2 tiles data from AWS."""
 

--- a/sentinelhub/aws/request.py
+++ b/sentinelhub/aws/request.py
@@ -5,10 +5,11 @@ Data request interface for downloading satellite data from AWS
 import functools
 from abc import abstractmethod
 from typing import Any, Generic, List, Optional, Tuple, TypeVar, Union
+from typing_extensions import deprecated
 
 from ..base import DataRequest
 from ..data_collections import DataCollection
-from ..exceptions import deprecated_class
+from ..exceptions import deprecated_class, SHDeprecationWarning
 from .client import AwsDownloadClient
 from .data import REQUESTER_PAYS_PARAMS, AwsProduct, AwsTile
 from .data_safe import SafeProduct, SafeTile
@@ -61,7 +62,10 @@ class _BaseAwsDataRequest(DataRequest, Generic[T]):
         return self.aws_service
 
 
-@deprecated_class(message_suffix="It will remain in the codebase for now, but won't be actively maintained.")
+@deprecated(
+    "AWS functionality will remain in the codebase for now, but won't be actively maintained.",
+    category=SHDeprecationWarning,
+)
 class AwsProductRequest(_BaseAwsDataRequest[AwsProduct]):
     """AWS Service request class for an ESA product."""
 
@@ -97,7 +101,10 @@ class AwsProductRequest(_BaseAwsDataRequest[AwsProduct]):
         self.download_list, self.folder_list = self.aws_service.get_requests()
 
 
-@deprecated_class(message_suffix="It will remain in the codebase for now, but won't be actively maintained.")
+@deprecated(
+    "AWS functionality will remain in the codebase for now, but won't be actively maintained.",
+    category=SHDeprecationWarning,
+)
 class AwsTileRequest(_BaseAwsDataRequest[AwsTile]):
     """AWS Service request class for an ESA tile."""
 

--- a/sentinelhub/aws/request.py
+++ b/sentinelhub/aws/request.py
@@ -9,7 +9,7 @@ from typing_extensions import deprecated
 
 from ..base import DataRequest
 from ..data_collections import DataCollection
-from ..exceptions import deprecated_class, SHDeprecationWarning
+from ..exceptions import SHDeprecationWarning
 from .client import AwsDownloadClient
 from .data import REQUESTER_PAYS_PARAMS, AwsProduct, AwsTile
 from .data_safe import SafeProduct, SafeTile

--- a/sentinelhub/config.py
+++ b/sentinelhub/config.py
@@ -153,13 +153,13 @@ class SHConfig(_SHConfig):
         profile = cls._get_profile(profile)
         filename = cls.get_config_location()
         if not os.path.exists(filename):
-            cls(use_defaults=True).save(profile)  # store default configuration to standard location
+            cls(use_defaults=True).save()  # store default configuration to standard location
 
         with open(filename, "rb") as cfg_file:
             configurations_dict = tomli.load(cfg_file)
 
         if profile not in configurations_dict:
-            raise KeyError(f"Profile {profile} not found in configuration file.")
+            raise KeyError(f"Profile `{profile}` not found in configuration file.")
 
         return cls(use_defaults=True, **configurations_dict[profile])
 

--- a/sentinelhub/exceptions.py
+++ b/sentinelhub/exceptions.py
@@ -7,7 +7,6 @@ import warnings
 from typing import Any, Callable
 
 import requests
-from typing_extensions import deprecated
 
 
 class BaseSentinelHubException(Exception):
@@ -64,7 +63,7 @@ warnings.simplefilter("always", SHRuntimeWarning)
 warnings.simplefilter("always", SHRateLimitWarning)
 
 
-@deprecated("Ironic, is it not? Use `typing_extensions.deprecated`.", category=SHDeprecationWarning)
+# THIS SHOULD BE REMOVED IN THE FUTURE, after rest of libraries transition away.
 def deprecated_function(
     category: type[DeprecationWarning] = SHDeprecationWarning, message_suffix: str | None = None
 ) -> Callable[[Callable], Callable]:
@@ -88,7 +87,7 @@ def deprecated_function(
     return deco
 
 
-@deprecated("Ironic, is it not? Use `typing_extensions.deprecated`.", category=SHDeprecationWarning)
+# THIS SHOULD BE REMOVED IN THE FUTURE, after rest of libraries transition away.
 def deprecated_class(
     category: type[DeprecationWarning] = SHDeprecationWarning, message_suffix: str | None = None
 ) -> Callable[[type], type]:

--- a/sentinelhub/exceptions.py
+++ b/sentinelhub/exceptions.py
@@ -7,6 +7,7 @@ import warnings
 from typing import Any, Callable
 
 import requests
+from typing_extensions import deprecated
 
 
 class BaseSentinelHubException(Exception):
@@ -63,6 +64,7 @@ warnings.simplefilter("always", SHRuntimeWarning)
 warnings.simplefilter("always", SHRateLimitWarning)
 
 
+@deprecated("Ironic, is it not? Use `typing_extensions.deprecated`.", category=SHDeprecationWarning)
 def deprecated_function(
     category: type[DeprecationWarning] = SHDeprecationWarning, message_suffix: str | None = None
 ) -> Callable[[Callable], Callable]:
@@ -86,6 +88,7 @@ def deprecated_function(
     return deco
 
 
+@deprecated("Ironic, is it not? Use `typing_extensions.deprecated`.", category=SHDeprecationWarning)
 def deprecated_class(
     category: type[DeprecationWarning] = SHDeprecationWarning, message_suffix: str | None = None
 ) -> Callable[[type], type]:

--- a/sentinelhub/geo_utils.py
+++ b/sentinelhub/geo_utils.py
@@ -6,8 +6,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Sequence, Tuple, cast
 
+from typing_extensions import deprecated
+
 from .constants import CRS
-from .exceptions import deprecated_function
+from .exceptions import SHDeprecationWarning
 
 if TYPE_CHECKING:
     from .geometry import BBox
@@ -83,7 +85,7 @@ def to_utm_bbox(bbox: BBox) -> BBox:
     return bbox.transform(utm_crs)
 
 
-@deprecated_function()
+@deprecated("The function `get_utm_bbox` has been deprecated.", category=SHDeprecationWarning)
 def get_utm_bbox(img_bbox: Sequence[float], transform: Sequence[float]) -> list[float]:
     """Get UTM coordinates given a bounding box in pixels and a transform
 
@@ -96,7 +98,10 @@ def get_utm_bbox(img_bbox: Sequence[float], transform: Sequence[float]) -> list[
     return [east1, north1, east2, north2]
 
 
-@deprecated_function(message_suffix="Use `transform_point` and `get_utm_crs` instead.")
+@deprecated(
+    "The function `wgs84_to_utm` has been deprecated. Use `transform_point` and `get_utm_crs` instead.",
+    category=SHDeprecationWarning,
+)
 def wgs84_to_utm(lng: float, lat: float, utm_crs: CRS | None = None) -> tuple[float, float]:
     """Convert WGS84 coordinates to UTM. If UTM CRS is not set it will be calculated automatically.
 
@@ -110,7 +115,9 @@ def wgs84_to_utm(lng: float, lat: float, utm_crs: CRS | None = None) -> tuple[fl
     return transform_point((lng, lat), CRS.WGS84, utm_crs)
 
 
-@deprecated_function(message_suffix="Use `transform_point` instead.")
+@deprecated(
+    "The function `to_wgs84` has been deprecated. Use `transform_point` instead.", category=SHDeprecationWarning
+)
 def to_wgs84(east: float, north: float, crs: CRS) -> tuple[float, float]:
     """Convert any CRS with (east, north) coordinates to WGS84
 
@@ -153,7 +160,7 @@ def pixel_to_utm(row: float, column: float, transform: Sequence[float]) -> tuple
     return east, north
 
 
-@deprecated_function()
+@deprecated("The function `wgs84_to_pixel` has been deprecated.", category=SHDeprecationWarning)
 def wgs84_to_pixel(
     lng: float, lat: float, transform: Sequence[float], utm_epsg: CRS | None = None, truncate: bool = True
 ) -> tuple[float, float] | tuple[int, int]:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -136,6 +136,20 @@ def test_profiles() -> None:
 
 @pytest.mark.dependency(depends=["test_user_config_is_masked"])
 @pytest.mark.usefixtures("_restore_config_file")
+def test_initialize_nondefault_profile() -> None:
+    """Since there is no config, loading a non-default profile should fail."""
+    config = SHConfig()
+    os.remove(config.get_config_location())
+
+    SHConfig()  # works for default
+
+    os.remove(config.get_config_location())
+    with pytest.raises(KeyError):
+        SHConfig("mr_president")
+
+
+@pytest.mark.dependency(depends=["test_user_config_is_masked"])
+@pytest.mark.usefixtures("_restore_config_file")
 def test_profiles_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
     """We use `monkeypatch` to avoid modifying global environment."""
     config = SHConfig()


### PR DESCRIPTION
The deprecator from typing_extensions has additional benefits of IDEs picking it up

![image](https://github.com/sentinel-hub/sentinelhub-py/assets/31988337/c62b8d38-13ab-47df-8cb5-81d25b9ab168)

I wanted to deprecate our own deprecators, but then users would get spammed with stuff that they have no control over (since it would happen on import. So I want to wait with that (or just remove them after a while)