### PR TITLE
Update session caching according to core auth changes

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,3 +1,7 @@
+## [Version 3.10.0] - 2023-12-07
+
+- Adjust session caching to mirror changes to the core services. Older version might no longer correctly cache sessions.
+
 ## [Version 3.9.5] - 2023-12-07
 
 - The `SentinelHubDownloadClient` class now has a `default_retry_time` parameter, which allows control over the waiting time when a request gets a 429 TOO_MANY_REQUESTS response without a specific retry time in the headers. The default value for this behavior has been changed from 0s to 30s to avoid edge-cases where SH services were bombarded with requests.

--- a/sentinelhub/_version.py
+++ b/sentinelhub/_version.py
@@ -1,3 +1,3 @@
 """Version of the sentinelhub package."""
 
-__version__ = "3.9.5"
+__version__ = "3.10.0"

--- a/sentinelhub/download/sentinelhub_client.py
+++ b/sentinelhub/download/sentinelhub_client.py
@@ -194,7 +194,7 @@ class SentinelHubDownloadClient(DownloadClient):
             base_url = config_or_session.config.sh_base_url
 
             # If session was generated from token then config_or_session.config.sh_client_id could have wrong client id.
-            sh_client_id = config_or_session.info().get("aud", "")
+            sh_client_id = config_or_session.info().get("azp", "")
             if not sh_client_id:
                 warnings.warn(
                     "Failed to read client ID from OAuth token. Session caching might not work correctly.",

--- a/tests/api/test_process.py
+++ b/tests/api/test_process.py
@@ -7,7 +7,7 @@ import json
 from typing import Any
 
 import pytest
-from oauthlib.oauth2.rfc6749.errors import CustomOAuth2Error
+from oauthlib.oauth2.rfc6749.errors import InvalidClientError
 from shapely.geometry import Polygon
 
 from sentinelhub import (
@@ -483,7 +483,7 @@ def test_bad_credentials() -> None:
     bad_credentials_config.sh_client_id = "test"
 
     request = SentinelHubRequest(**request_params, config=bad_credentials_config)
-    with pytest.raises(CustomOAuth2Error):
+    with pytest.raises(InvalidClientError):
         request.get_data()
 
     missing_credentials_config = SHConfig()

--- a/tests/download/test_session.py
+++ b/tests/download/test_session.py
@@ -48,10 +48,7 @@ def test_session(session: SentinelHubSession) -> None:
 
 @pytest.mark.sh_integration()
 def test_token_info(session: SentinelHubSession) -> None:
-    info = session.info()
-
-    for key in ["exp", "iat", "jti", "iss", "sub", "typ", "azp", "scope", "account"]:
-        assert key in info
+    assert "azp" in session.info()
 
 
 def test_session_content_and_headers(fake_config: SHConfig, fake_token: dict[str, Any], requests_mock: Mocker) -> None:

--- a/tests/download/test_session.py
+++ b/tests/download/test_session.py
@@ -5,7 +5,7 @@ from concurrent.futures import ProcessPoolExecutor
 from typing import Any
 
 import pytest
-from oauthlib.oauth2.rfc6749.errors import CustomOAuth2Error
+from oauthlib.oauth2.rfc6749.errors import CustomOAuth2Error, InvalidClientError
 from requests_mock import Mocker
 
 from sentinelhub import SentinelHubSession, SHConfig, __version__
@@ -50,7 +50,7 @@ def test_session(session: SentinelHubSession) -> None:
 def test_token_info(session: SentinelHubSession) -> None:
     info = session.info()
 
-    for key in ["sub", "aud", "jti", "exp", "name", "email", "sid", "org", "did", "aid", "d"]:
+    for key in ["exp", "iat", "jti", "iss", "sub", "typ", "azp", "scope", "account"]:
         assert key in info
 
 
@@ -108,7 +108,7 @@ def test_refreshing_procedure(fake_token: JsonDict, fake_config: SHConfig) -> No
         assert session.token == fake_token
 
     session = SentinelHubSession(config=fake_config, refresh_before_expiry=500, _token=fake_token)
-    with pytest.raises(CustomOAuth2Error):
+    with pytest.raises(InvalidClientError):
         _ = session.token
 
 


### PR DESCRIPTION
I was thinking of making this a major release since older versions might no longer cache sessions correctly.