### PR TITLE
Change auth endpoint default

### DIFF
--- a/sentinelhub/config.py
+++ b/sentinelhub/config.py
@@ -30,7 +30,7 @@ class _SHConfig:
     sh_client_secret: str = ""
     sh_base_url: str = "https://services.sentinel-hub.com"
     sh_auth_base_url: str | None = None
-    sh_token_url: str = "https://services.sentinel-hub.com/oauth/token"
+    sh_token_url: str = "https://services.sentinel-hub.com/auth/realms/main/protocol/openid-connect/token"
     geopedia_wms_url: str = "https://service.geopedia.world"
     geopedia_rest_url: str = "https://www.geopedia.world/rest"
     aws_access_key_id: str = ""

--- a/tests/download/test_session.py
+++ b/tests/download/test_session.py
@@ -53,7 +53,7 @@ def test_token_info(session: SentinelHubSession) -> None:
 
 def test_session_content_and_headers(fake_config: SHConfig, fake_token: dict[str, Any], requests_mock: Mocker) -> None:
     """Make sure correct content and headers are passed to the service."""
-    requests_mock.post(url="/oauth/token", response_list=[{"json": fake_token}])
+    requests_mock.post(url=fake_config.sh_token_url, response_list=[{"json": fake_token}])
     call_time = time.time()
     token = SentinelHubSession(config=fake_config).token
     # "expires_at" is derived from "expires_in"  and not read from the response field "expires_at"
@@ -125,11 +125,7 @@ def test_oauth_compliance_hook_4xx(
     expected_exception: type[Exception],
     fake_config: SHConfig,
 ) -> None:
-    requests_mock.post(
-        "https://services.sentinel-hub.com/oauth/token",
-        json=response_payload,
-        status_code=status_code,
-    )
+    requests_mock.post(fake_config.sh_token_url, json=response_payload, status_code=status_code)
 
     with pytest.raises(expected_exception):
         SentinelHubSession(config=fake_config)
@@ -148,11 +144,7 @@ def test_oauth_compliance_hook_4xx(
 def test_oauth_compliance_hook_5xx(
     requests_mock: Mocker, status_code: int, response_payload: JsonDict | None, fake_config: SHConfig
 ) -> None:
-    requests_mock.post(
-        "https://services.sentinel-hub.com/oauth/token",
-        json=response_payload,
-        status_code=status_code,
-    )
+    requests_mock.post(fake_config.sh_token_url, json=response_payload, status_code=status_code)
 
     fake_config.max_download_attempts = 10
     fake_config.download_sleep_time = 0


### PR DESCRIPTION
The old URL has a redirect, but we should switch to the correct one