### PR TITLE
Add configuration to limit rate limit retries

### DIFF
--- a/sentinelhub/config.py
+++ b/sentinelhub/config.py
@@ -46,6 +46,7 @@ class _SHConfig:
     download_sleep_time: float = 5.0
     download_timeout_seconds: float = 120.0
     number_of_download_processes: int = 1
+    max_rate_limit_retries: int | None = None
 
     def __post_init__(self) -> None:
         if self.sh_auth_base_url is not None:
@@ -94,6 +95,7 @@ class SHConfig(_SHConfig):
           attempt this number exponentially increases with factor `3`.
         - `download_timeout_seconds`: Maximum number of seconds before download attempt is canceled.
         - `number_of_download_processes`: Number of download processes, used to calculate rate-limit sleep time.
+        - `max_rate_limit_retries`: Maximum number of retries caused by rate limits until an exception is raised.
 
     The location of `config.toml` for manual modification can be found with `SHConfig.get_config_location()`.
     """

--- a/sentinelhub/config.py
+++ b/sentinelhub/config.py
@@ -46,7 +46,7 @@ class _SHConfig:  # pylint: disable=too-many-instance-attributes
     download_sleep_time: float = 5.0
     download_timeout_seconds: float = 120.0
     number_of_download_processes: int = 1
-    max_rate_limit_retries: int | None = None
+    max_retries: int | None = None
 
     def __post_init__(self) -> None:
         if self.sh_auth_base_url is not None:
@@ -95,7 +95,7 @@ class SHConfig(_SHConfig):
           attempt this number exponentially increases with factor `3`.
         - `download_timeout_seconds`: Maximum number of seconds before download attempt is canceled.
         - `number_of_download_processes`: Number of download processes, used to calculate rate-limit sleep time.
-        - `max_rate_limit_retries`: Maximum number of retries caused by rate limits until an exception is raised.
+        - `max_retries`: Maximum number of retries until an exception is raised.
 
     The location of `config.toml` for manual modification can be found with `SHConfig.get_config_location()`.
     """

--- a/sentinelhub/config.py
+++ b/sentinelhub/config.py
@@ -24,7 +24,7 @@ SH_CLIENT_SECRET_ENV_VAR = "SH_CLIENT_SECRET"
 
 
 @dataclass(repr=False)
-class _SHConfig:
+class _SHConfig:  # pylint: disable=too-many-instance-attributes
     instance_id: str = ""
     sh_client_id: str = ""
     sh_client_secret: str = ""

--- a/sentinelhub/download/sentinelhub_client.py
+++ b/sentinelhub/download/sentinelhub_client.py
@@ -91,10 +91,7 @@ class SentinelHubDownloadClient(DownloadClient):
 
                 if response.status_code == requests.status_codes.codes.TOO_MANY_REQUESTS:
                     warnings.warn("Download rate limit hit", category=SHRateLimitWarning)
-                    if (
-                        self.config.max_rate_limit_retries is not None
-                        and download_attempts >= self.config.max_rate_limit_retries
-                    ):
+                    if self.config.max_retries is not None and download_attempts >= self.config.max_retries:
                         raise OutOfRequestsException("Maximum number of download attempts reached")
 
                     self._execute_thread_safe(self.rate_limit.update, response.headers, default=self.default_retry_time)

--- a/tests/download/test_sentinelhub_client.py
+++ b/tests/download/test_sentinelhub_client.py
@@ -118,9 +118,9 @@ def test_universal_session_caching(session: SentinelHubSession) -> None:
 
 
 @pytest.mark.sh_integration()
-def test_client_with_max_rate_limit_retries(session: SentinelHubSession) -> None:
+def test_client_with_max_retries(session: SentinelHubSession) -> None:
     blank_config = SHConfig(use_defaults=True)
-    blank_config.max_rate_limit_retries = 1
+    blank_config.max_retries = 1
     client = SentinelHubDownloadClient(session=session, config=blank_config)
 
     class MockResponse:

--- a/tests/download/test_sentinelhub_client.py
+++ b/tests/download/test_sentinelhub_client.py
@@ -1,15 +1,18 @@
 from __future__ import annotations
 
 import pytest
+import requests
 from requests_mock import Mocker
 
 from sentinelhub import (
+    DownloadRequest,
     SentinelHubDownloadClient,
     SentinelHubSession,
     SentinelHubStatisticalDownloadClient,
     SHConfig,
     __version__,
 )
+from sentinelhub.exceptions import OutOfRequestsException
 
 FAST_SH_ENDPOINT = "https://services.sentinel-hub.com/api/v1/catalog/collections"
 # ruff: noqa: SLF001
@@ -112,3 +115,18 @@ def test_universal_session_caching(session: SentinelHubSession) -> None:
     SentinelHubDownloadClient.cache_session(session, universal=True)
     cached_session = client.get_session()
     assert cached_session is session
+
+
+@pytest.mark.sh_integration()
+def test_client_with_max_rate_limit_retries(session: SentinelHubSession) -> None:
+    blank_config = SHConfig(use_defaults=True)
+    blank_config.max_rate_limit_retries = 1
+    client = SentinelHubDownloadClient(session=session, config=blank_config)
+
+    class MockResponse:
+        def __init__(self):
+            self.status_code = requests.status_codes.codes.TOO_MANY_REQUESTS
+
+    client._do_download = lambda _: MockResponse()
+    with pytest.raises(OutOfRequestsException):
+        client.download(download_requests=[DownloadRequest()])


### PR DESCRIPTION
At the moment the default behaviour is to retry requests indefinitely when rate limits are reached on the server side. For some use-cases it would be helpful to limit this behaviour, and allow the calling code to handle this with some backoff mechanism. In particular, if multiple processes are submitting requests it does not make sense for them to compete over the finite rate limit.

To achieve this I have added a new config called `max_rate_limit_retries`, which is `None` by default. If this configuration has a numeric value we will raise an `OutOfRequestsException` once the number of download attempts has exceeded the configuration value. I am open to changing the naming if necessary.