### PR TITLE
Wait for batch process API job to update status from PROCESSING to something else

### DIFF
--- a/sentinelhub/api/batch/utils.py
+++ b/sentinelhub/api/batch/utils.py
@@ -93,6 +93,13 @@ def monitor_batch_job(
     failed_tiles_num = finished_count - success_count
     if failed_tiles_num:
         LOGGER.info("Batch job failed for %d tiles", failed_tiles_num)
+
+    LOGGER.info("Waiting on batch job status update.")
+    while batch_request.status is BatchRequestStatus.PROCESSING:
+        time.sleep(sleep_time)
+        batch_request = batch_client.get_request(batch_request)
+
+    LOGGER.info("Batch job finished with status %s", batch_request.status.value)
     return tiles_per_status
 
 


### PR DESCRIPTION
A simple addition with more descriptions.

Another option would be to run the `while` loop as long as the status is `PROCESSING`, but perhaps the user would be confused why the job doesn't move forward as soon as the progress bars hit 100%. An additional reason is that the suggested implementation is perhaps more informative