### PR TITLE
Stop batch job monitoring if a batch job is canceled

### DIFF
--- a/sentinelhub/api/batch/utils.py
+++ b/sentinelhub/api/batch/utils.py
@@ -97,8 +97,8 @@ def monitor_batch_job(
     if failed_tiles_num:
         LOGGER.info("Batch job failed for %d tiles", failed_tiles_num)
 
-    LOGGER.info("Waiting on batch job status update.")
     while batch_request.status is BatchRequestStatus.PROCESSING:
+        LOGGER.info("Waiting on batch job status update.")
         time.sleep(sleep_time)
         batch_request = batch_client.get_request(batch_request)
 

--- a/sentinelhub/api/batch/utils.py
+++ b/sentinelhub/api/batch/utils.py
@@ -77,6 +77,9 @@ def monitor_batch_job(
         while finished_count < batch_request.tile_count:
             time.sleep(sleep_time)
 
+            batch_request = batch_client.get_request(batch_request)
+            batch_request.raise_for_status(status=[BatchRequestStatus.CANCELED])
+
             tiles_per_status = _get_batch_tiles_per_status(batch_request, batch_client)
             new_success_count = len(tiles_per_status[BatchTileStatus.PROCESSED])
             new_finished_count = new_success_count + len(tiles_per_status[BatchTileStatus.FAILED])

--- a/sentinelhub/api/batch/utils.py
+++ b/sentinelhub/api/batch/utils.py
@@ -73,12 +73,12 @@ def monitor_batch_job(
 
     progress_bar = tqdm(total=batch_request.tile_count, initial=finished_count, desc="Progress rate")
     success_bar = tqdm(total=finished_count, initial=success_count, desc="Success rate")
-    with progress_bar, success_bar:
-        while finished_count < batch_request.tile_count:
-            time.sleep(sleep_time)
 
+    monitoring_status = [BatchRequestStatus.ANALYSIS_DONE, BatchRequestStatus.PROCESSING]
+    with progress_bar, success_bar:
+        while finished_count < batch_request.tile_count and batch_request.status in monitoring_status:
+            time.sleep(sleep_time)
             batch_request = batch_client.get_request(batch_request)
-            batch_request.raise_for_status(status=[BatchRequestStatus.CANCELED])
 
             tiles_per_status = _get_batch_tiles_per_status(batch_request, batch_client)
             new_success_count = len(tiles_per_status[BatchTileStatus.PROCESSED])

--- a/tests/api/batch/test_utils.py
+++ b/tests/api/batch/test_utils.py
@@ -103,7 +103,7 @@ def test_monitor_batch_process_job(
 
     is_processing_logged = batch_status is BatchRequestStatus.PROCESSING
     is_failure_logged = BatchTileStatus.FAILED in tile_status_sequence[-1]
-    assert logging_mock.call_count == int(is_processing_logged) + int(is_failure_logged) + 2
+    assert logging_mock.call_count == int(is_processing_logged) + int(is_failure_logged) + additional_calls + 1
 
 
 def test_canceled_batch_process_job(mocker: MockerFixture) -> None:

--- a/tests/api/batch/test_utils.py
+++ b/tests/api/batch/test_utils.py
@@ -134,8 +134,6 @@ def test_canceled_batch_process_job(mocker: MockerFixture) -> None:
     with pytest.raises(RuntimeError):
         monitor_batch_job("mocked-request", config=SHConfig(), sleep_time=60)
 
-    assert monitor_analysis_mock.call_count == 1
-
 
 def _tile_status_counts_to_tiles(tile_status_counts: dict[BatchTileStatus, int]) -> list[dict[str, str]]:
     """From the info about how many tiles should have certain status it generates a list of tile payloads with these

--- a/tests/api/batch/test_utils.py
+++ b/tests/api/batch/test_utils.py
@@ -106,6 +106,37 @@ def test_monitor_batch_process_job(
     assert logging_mock.call_count == int(is_processing_logged) + int(is_failure_logged) + 2
 
 
+def test_canceled_batch_process_job(mocker: MockerFixture) -> None:
+
+    tile_status_sequence = [{BatchTileStatus.PROCESSING: 6}, {BatchTileStatus.PROCESSING: 6}]
+    tiles_sequence = [_tile_status_counts_to_tiles(tile_status_counts) for tile_status_counts in tile_status_sequence]
+    tile_count = len(tiles_sequence[0])
+    assert all(
+        len(tiles) == tile_count for tiles in tiles_sequence
+    ), "There should be the same number of tiles in each step. Fix tile_status_sequence parameter of this test."
+
+    batch_kwargs = dict(request_id="mocked-request", process_request={}, tile_count=tile_count)
+    batch_request_sequence = [
+        BatchRequest(**batch_kwargs, status=status)
+        for status in [BatchRequestStatus.PROCESSING, BatchRequestStatus.CANCELED]
+    ]
+
+    monitor_analysis_mock = mocker.patch("sentinelhub.api.batch.utils.monitor_batch_analysis")
+    monitor_analysis_mock.return_value = batch_request_sequence[0]
+
+    batch_request_update_mock = mocker.patch("sentinelhub.SentinelHubBatch.get_request")
+    batch_request_update_mock.side_effect = batch_request_sequence
+
+    batch_tiles_mock = mocker.patch("sentinelhub.SentinelHubBatch.iter_tiles")
+    batch_tiles_mock.side_effect = tiles_sequence
+
+    mocker.patch("time.sleep")
+    with pytest.raises(RuntimeError):
+        monitor_batch_job("mocked-request", config=SHConfig(), sleep_time=60)
+
+    assert monitor_analysis_mock.call_count == 1
+
+
 def _tile_status_counts_to_tiles(tile_status_counts: dict[BatchTileStatus, int]) -> list[dict[str, str]]:
     """From the info about how many tiles should have certain status it generates a list of tile payloads with these
     statuses.


### PR DESCRIPTION
- stops early if a job is canceled
- other small behavior and test updates