### PR TITLE
Fix for is_empty vs non-empty area.

### DIFF
--- a/sentinelhub/areas.py
+++ b/sentinelhub/areas.py
@@ -534,7 +534,7 @@ class BaseUtmSplitter(AreaSplitter, metaclass=ABCMeta):
                     geo_object for geo_object in intersection if isinstance(geo_object, (Polygon, MultiPolygon))
                 )
 
-            if not intersection.is_empty:
+            if intersection.area > 0:
                 intersection = Geometry(intersection, CRS.WGS84).transform(utm_crs)
 
                 bbox_partition = self._align_bbox_to_size(intersection.bbox).get_partition(size_x=size_x, size_y=size_y)

--- a/tests/test_areas.py
+++ b/tests/test_areas.py
@@ -46,6 +46,7 @@ BBOX_GRID = [
         (UtmGridSplitter, ([AREA], CRS.WGS84), dict(bbox_size=(1200, 1200)), 16),
         (UtmZoneSplitter, ([AREA], CRS.WGS84), dict(bbox_size=(1000, 1000)), 19),
         (UtmZoneSplitter, ([AREA], CRS.WGS84), dict(bbox_size=(1000, 1000), offset=(500, 500)), 21),
+        (UtmZoneSplitter, ([shapely.box(0, 0, 1, 1)], CRS.WGS84), dict(bbox_size=(10000, 10000)), 144),
         pytest.param(
             TileSplitter,
             ([AREA], CRS.WGS84, ("2017-10-01", "2018-03-01")),


### PR DESCRIPTION
Sometimes the intersection will result in a geometry type LineString (or similar), for which the `is_empty` will return False, but `sentinelhub.Geometry` init will fail as the geometry is neither `Polygon` nor `MultiPolygon`. 



