### PR TITLE
Add wait wrapper around Batch V1/V2 user action calls until the status changes

### DIFF
--- a/sentinelhub/api/batch/process.py
+++ b/sentinelhub/api/batch/process.py
@@ -11,7 +11,7 @@ import time
 from dataclasses import dataclass, field
 from enum import Enum
 from functools import wraps
-from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple, TypeVar, Union
 
 from dataclasses_json import CatchAll, LetterCase, Undefined, dataclass_json
 from dataclasses_json import config as dataclass_config
@@ -27,13 +27,15 @@ from .base import BaseBatchClient, BaseBatchRequest, BatchRequestStatus, BatchUs
 
 LOGGER = logging.getLogger(__name__)
 
+T = TypeVar("T", bound="SentinelHubBatch")
+
 BatchRequestType = Union[str, dict, "BatchRequest"]
 BatchCollectionType = Union[str, dict, "BatchCollection"]
 
 
 def batch_user_action_wait_for_status_change(func: Callable) -> Callable:
     @wraps(func)
-    def retrying_func(self: SentinelHubBatch, batch_request: BatchRequest) -> Json:
+    def retrying_func(self: T, batch_request: "BatchRequest") -> Json:
         status = batch_request.status
         output = func(self, batch_request)
         for wait_time in [1, 2, 5, 10, 20, 100]:

--- a/sentinelhub/api/batch/process.py
+++ b/sentinelhub/api/batch/process.py
@@ -7,9 +7,11 @@ Module implementing an interface with
 # do not use `from __future__ import annotations`, it clashes with `dataclass_json`
 import datetime as dt
 import logging
+import time
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
+from functools import wraps
+from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple, Union
 
 from dataclasses_json import CatchAll, LetterCase, Undefined, dataclass_json
 from dataclasses_json import config as dataclass_config
@@ -27,6 +29,23 @@ LOGGER = logging.getLogger(__name__)
 
 BatchRequestType = Union[str, dict, "BatchRequest"]
 BatchCollectionType = Union[str, dict, "BatchCollection"]
+
+
+def _batch_user_action_wait_for_status_change(func: Callable) -> Callable:
+    @wraps(func)
+    def retrying_func(self, batch_request: BatchRequestType):
+        status = batch_request.status
+        output = func(self, batch_request)
+        for wait_time in [1, 2, 5, 10, 20, 100]:
+            time.sleep(wait_time)
+            new_status = self.get_request(batch_request).status
+            if new_status != status:
+                return output
+
+        LOGGER.warning(f"Status of batch request {batch_request.request_id} did not change from {status} in time!")
+        return output
+
+    return retrying_func
 
 
 class BatchTileStatus(Enum):
@@ -280,6 +299,7 @@ class SentinelHubBatch(BaseBatchClient):
             url=self._get_processing_url(request_id), request_type=RequestType.DELETE, use_session=True
         )
 
+    @_batch_user_action_wait_for_status_change
     def start_analysis(self, batch_request: BatchRequestType) -> Json:
         """Starts analysis of a batch job request
 
@@ -290,6 +310,7 @@ class SentinelHubBatch(BaseBatchClient):
         """
         return self._call_job(batch_request, "analyse")
 
+    @_batch_user_action_wait_for_status_change
     def start_job(self, batch_request: BatchRequestType) -> Json:
         """Starts running a batch job
 
@@ -300,6 +321,7 @@ class SentinelHubBatch(BaseBatchClient):
         """
         return self._call_job(batch_request, "start")
 
+    @_batch_user_action_wait_for_status_change
     def cancel_job(self, batch_request: BatchRequestType) -> Json:
         """Cancels a batch job
 
@@ -311,6 +333,7 @@ class SentinelHubBatch(BaseBatchClient):
         """
         return self._call_job(batch_request, "cancel")
 
+    @_batch_user_action_wait_for_status_change
     def restart_job(self, batch_request: BatchRequestType) -> Json:
         """Restarts only those parts of a job that failed
 

--- a/sentinelhub/api/batch/process.py
+++ b/sentinelhub/api/batch/process.py
@@ -33,7 +33,7 @@ BatchCollectionType = Union[str, dict, "BatchCollection"]
 
 def batch_user_action_wait_for_status_change(func: Callable) -> Callable:
     @wraps(func)
-    def retrying_func(self, batch_request: Union[str, dict, BaseBatchRequest]):
+    def retrying_func(self: SentinelHubBatch, batch_request: BatchRequest) -> Json:
         status = batch_request.status
         output = func(self, batch_request)
         for wait_time in [1, 2, 5, 10, 20, 100]:

--- a/sentinelhub/api/batch/process.py
+++ b/sentinelhub/api/batch/process.py
@@ -31,9 +31,9 @@ BatchRequestType = Union[str, dict, "BatchRequest"]
 BatchCollectionType = Union[str, dict, "BatchCollection"]
 
 
-def _batch_user_action_wait_for_status_change(func: Callable) -> Callable:
+def batch_user_action_wait_for_status_change(func: Callable) -> Callable:
     @wraps(func)
-    def retrying_func(self, batch_request: BatchRequestType):
+    def retrying_func(self, batch_request: Union[str, dict, BaseBatchRequest]):
         status = batch_request.status
         output = func(self, batch_request)
         for wait_time in [1, 2, 5, 10, 20, 100]:
@@ -299,7 +299,7 @@ class SentinelHubBatch(BaseBatchClient):
             url=self._get_processing_url(request_id), request_type=RequestType.DELETE, use_session=True
         )
 
-    @_batch_user_action_wait_for_status_change
+    @batch_user_action_wait_for_status_change
     def start_analysis(self, batch_request: BatchRequestType) -> Json:
         """Starts analysis of a batch job request
 
@@ -310,7 +310,7 @@ class SentinelHubBatch(BaseBatchClient):
         """
         return self._call_job(batch_request, "analyse")
 
-    @_batch_user_action_wait_for_status_change
+    @batch_user_action_wait_for_status_change
     def start_job(self, batch_request: BatchRequestType) -> Json:
         """Starts running a batch job
 
@@ -321,7 +321,7 @@ class SentinelHubBatch(BaseBatchClient):
         """
         return self._call_job(batch_request, "start")
 
-    @_batch_user_action_wait_for_status_change
+    @batch_user_action_wait_for_status_change
     def cancel_job(self, batch_request: BatchRequestType) -> Json:
         """Cancels a batch job
 
@@ -333,7 +333,7 @@ class SentinelHubBatch(BaseBatchClient):
         """
         return self._call_job(batch_request, "cancel")
 
-    @_batch_user_action_wait_for_status_change
+    @batch_user_action_wait_for_status_change
     def restart_job(self, batch_request: BatchRequestType) -> Json:
         """Restarts only those parts of a job that failed
 

--- a/sentinelhub/api/batch/process.py
+++ b/sentinelhub/api/batch/process.py
@@ -34,6 +34,8 @@ BatchCollectionType = Union[str, dict, "BatchCollection"]
 
 
 def batch_user_action_wait_for_status_change(func: Callable) -> Callable:
+    """Decorator function for waiting for a status change after a user action."""
+
     @wraps(func)
     def retrying_func(self: T, batch_request: "BatchRequest") -> Json:
         status = batch_request.status
@@ -44,7 +46,9 @@ def batch_user_action_wait_for_status_change(func: Callable) -> Callable:
             if new_status != status:
                 return output
 
-        LOGGER.warning(f"Status of batch request {batch_request.request_id} did not change from {status} in time!")
+        LOGGER.warning(
+            "Status of batch request %s did not change from %s in time!", batch_request.request_id, status.value
+        )
         return output
 
     return retrying_func

--- a/sentinelhub/api/batch/process_v2.py
+++ b/sentinelhub/api/batch/process_v2.py
@@ -20,6 +20,7 @@ from ..base import SentinelHubFeatureIterator
 from ..process import SentinelHubRequest
 from ..utils import AccessSpecification, datetime_config, enum_config, remove_undefined, s3_specification
 from .base import BaseBatchClient, BaseBatchRequest, BatchRequestStatus, BatchUserAction, StoppedStatusReason
+from .process import batch_user_action_wait_for_status_change
 
 LOGGER = logging.getLogger(__name__)
 
@@ -249,6 +250,7 @@ class BatchProcessClient(BaseBatchClient):
             use_session=True,
         )
 
+    @batch_user_action_wait_for_status_change
     def start_analysis(self, batch_request: BatchRequestType) -> Json:
         """Starts analysis of a batch job request
 
@@ -256,6 +258,7 @@ class BatchProcessClient(BaseBatchClient):
         """
         return self._call_job(batch_request, "analyse")
 
+    @batch_user_action_wait_for_status_change
     def start_job(self, batch_request: BatchRequestType) -> Json:
         """Starts running a batch job
 
@@ -263,6 +266,7 @@ class BatchProcessClient(BaseBatchClient):
         """
         return self._call_job(batch_request, "start")
 
+    @batch_user_action_wait_for_status_change
     def stop_job(self, batch_request: BatchRequestType) -> Json:
         """Stops a batch job
 


### PR DESCRIPTION
- Added a simple wrapper which first saves the old status before performing the action, then it repeatedly checks for a status update until the wait is over. if the status doesn't change, it logs a warning
- added also for Batch V2
- added mocked tests for both